### PR TITLE
Add first-pass scriptable dynamic texture controls

### DIFF
--- a/Source/Core/Script/ERS_CLASS_LuaJITInterpreterIntegration/ERS_CLASS_LuaJITInterpreterIntegration.cpp
+++ b/Source/Core/Script/ERS_CLASS_LuaJITInterpreterIntegration/ERS_CLASS_LuaJITInterpreterIntegration.cpp
@@ -2,6 +2,7 @@
 // This file is part of the BrainGenix-ERS Environment Rendering System //
 //======================================================================//
 
+#include <algorithm>
 #include <ERS_CLASS_LuaJITInterpreterIntegration.h>
 
 ERS_CLASS_LuaJITInterpreterIntegration::ERS_CLASS_LuaJITInterpreterIntegration(BG::Common::Logger::LoggingSystem* Logger)
@@ -133,6 +134,20 @@ bool ERS_CLASS_LuaJITInterpreterIntegration::ExecuteSceneCameraScript(std::strin
     lua_setglobal(L,"ScaleZ");
     lua_pushnumber(L, Model->Enabled);
     lua_setglobal(L,"Enabled");
+    lua_pushnumber(L, Model->TextureLevelInRAM_);
+    lua_setglobal(L, "TextureLevelInRAM");
+    lua_pushnumber(L, Model->TextureLevelInVRAM_);
+    lua_setglobal(L, "TextureLevelInVRAM");
+    lua_pushnumber(L, Model->TargetTextureLevelRAM);
+    lua_setglobal(L, "TargetTextureLevelRAM");
+    lua_pushnumber(L, Model->TargetTextureLevelVRAM);
+    lua_setglobal(L, "TargetTextureLevelVRAM");
+    lua_pushnumber(L, Model->UserLimitedMinLOD_);
+    lua_setglobal(L, "MinTextureLOD");
+    lua_pushnumber(L, Model->UserLimitedMaxLOD_);
+    lua_setglobal(L, "MaxTextureLOD");
+    lua_pushnumber(L, Model->MaxTextureLevel_);
+    lua_setglobal(L, "ModelMaxTextureLOD");
 
 
     // Load the Lua script
@@ -160,6 +175,16 @@ bool ERS_CLASS_LuaJITInterpreterIntegration::ExecuteSceneCameraScript(std::strin
     Model->ModelRotation.z = (float)lua_tonumber(L, -1);
     lua_getglobal(L, "Enabled");
     Model->Enabled= (float)lua_tonumber(L, -1);
+    lua_getglobal(L, "MinTextureLOD");
+    Model->UserLimitedMinLOD_ = std::max(-1, (int)lua_tonumber(L, -1));
+    lua_getglobal(L, "MaxTextureLOD");
+    Model->UserLimitedMaxLOD_ = std::max(Model->UserLimitedMinLOD_, std::min(Model->MaxTextureLevel_, (int)lua_tonumber(L, -1)));
+    lua_getglobal(L, "TargetTextureLevelRAM");
+    Model->TargetTextureLevelRAM = std::max(0, std::min(Model->UserLimitedMaxLOD_, (int)lua_tonumber(L, -1)));
+    Model->TargetTextureLevelRAM = std::max(Model->UserLimitedMinLOD_, Model->TargetTextureLevelRAM);
+    lua_getglobal(L, "TargetTextureLevelVRAM");
+    Model->TargetTextureLevelVRAM = std::max(0, std::min(Model->UserLimitedMaxLOD_, (int)lua_tonumber(L, -1)));
+    Model->TargetTextureLevelVRAM = std::max(Model->UserLimitedMinLOD_, Model->TargetTextureLevelVRAM);
 
     lua_close(L);
     return true;


### PR DESCRIPTION
Fixes #96.

This adds a first-pass dynamic texture control path for model scripts by exposing the existing texture streaming state and targets to Lua.

Included in this patch:

- exposes `TextureLevelInRAM`, `TextureLevelInVRAM`, `TargetTextureLevelRAM`, `TargetTextureLevelVRAM`, `MinTextureLOD`, `MaxTextureLOD`, and `ModelMaxTextureLOD` to `ExecuteModelScript(...)`
- writes script changes for the target texture levels and user LOD limits back onto the model after script execution
- clamps script-provided LOD values so they stay inside the model's known texture-level range and existing user LOD limits
- keeps the first pass intentionally narrow by reusing the existing streaming system rather than adding new texture asset swapping or animated-image formats

Verification:

- reviewed the isolated file diff for this patch
- `git diff --check` passed for the touched file
- local C++ build/runtime verification is still pending because the full ERS dependency stack is not installed in this environment

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.