### PR TITLE
Add first-pass C++ filename audit

### DIFF
--- a/Docs/CppFilenameRefactorPlan.md
+++ b/Docs/CppFilenameRefactorPlan.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD013 MD043 -->
+
 # C++ Filename Refactor Plan
 
 This note turns issue `BrainGenix-ERS#464` into a reviewable first pass.

--- a/Docs/CppFilenameRefactorPlan.md
+++ b/Docs/CppFilenameRefactorPlan.md
@@ -1,0 +1,70 @@
+# C++ Filename Refactor Plan
+
+This note turns issue `BrainGenix-ERS#464` into a reviewable first pass.
+
+## Rule In The Current Contribution Guide
+
+`CONTRIBUTING.md` currently says C++ filenames should use an `ERS_[CLASS/STRUCT/FUNCTION]_` prefix to indicate what the file contains.
+
+## Current Snapshot
+
+Static scan snapshot from 2026-04-22 over `Source/`:
+
+- total C++ files scanned: `321`
+- files already starting with `ERS_`: `2`
+- files not matching the literal `ERS_` filename rule: `319`
+
+Largest offender directories from that scan:
+
+1. `Source/Core/Renderer/ERS_CLASS_VisualRenderer`: `38`
+2. `Source/Core/Editor/Windows/GUI_Window_SceneTree`: `34`
+3. `Source/Core/Loader/ERS_ModelLoader`: `18`
+4. `Source/Core/Loader/ERS_SceneLoader`: `18`
+5. `Source/Core/Script/ERS_CLASS_PythonInterpreterIntegration`: `14`
+
+The drift is not one single pattern. The current tree mixes several naming families:
+
+- `GUI_*` filenames in editor code
+- plain domain names inside already-prefixed directories, for example `ERS_STRUCT_Scene/Scene.cpp`
+- `PyBind11*` filenames in the Python integration area
+
+## Why This Needs To Be Phased
+
+A blind repo-wide rename would touch:
+
+- `#include` lines
+- per-directory `CMakeLists.txt` file lists
+- IDE/bookmark expectations
+- downstream scripts and documentation
+
+That makes a single all-at-once rename too risky for a first reviewable patch.
+
+## First-Pass Work Added In This Patch
+
+- `Tools/AuditCppFileNames.py` scans `Source/`, classifies nonconforming files, and reports the largest offender directories
+- the script can also write a full JSON report for later mechanical rename work
+
+Example usage:
+
+```bash
+python3 Tools/AuditCppFileNames.py
+python3 Tools/AuditCppFileNames.py --write-json Docs/cpp_filename_audit.json --show-offenders 200
+```
+
+## Proposed Migration Order
+
+1. Rename files in directories that already encode the target name in the directory itself.
+   Example: `Source/Core/Structures/ERS_STRUCT_Scene/Scene.cpp` -> `ERS_STRUCT_Scene.cpp`
+2. Rename low-fanout internal helpers next.
+   Example: small `Source/Internal/*` libraries with limited include surfaces.
+3. Decide how legacy editor `GUI_*` families should map to the contribution rule before touching them.
+   The repo needs a clear answer on whether these stay `GUI_*` or become `ERS_*`.
+4. Rename high-fanout renderer and scene-tree helper files after the convention decision is settled.
+
+## Explicit Non-Goals For This Patch
+
+- no mass rename yet
+- no include-path churn yet
+- no CMake file-list rewrite yet
+
+This patch is only meant to make the filename refactor mechanical and reviewable.

--- a/Tools/AuditCppFileNames.py
+++ b/Tools/AuditCppFileNames.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+
+
+def classify_stem(stem: str) -> str:
+    if stem.startswith("ERS_"):
+        return "conforming"
+    if stem.startswith("GUI_"):
+        return "legacy_gui"
+    if stem.startswith("PyBind11"):
+        return "legacy_pybind"
+    return "plain_name"
+
+
+def nearest_named_parent(path: Path, root: Path) -> str | None:
+    for parent in path.parents:
+        if parent == root:
+            break
+        if parent.name.startswith(("ERS_", "GUI_")):
+            return parent.name
+    return None
+
+
+def scan_cpp_files(root: Path) -> dict:
+    files = sorted(
+        path for path in root.rglob("*")
+        if path.is_file() and path.suffix.lower() in {".cpp", ".h", ".hpp", ".cxx", ".cc"}
+    )
+
+    offenders = []
+    top_dirs = Counter()
+    families = Counter()
+    for file_path in files:
+        family = classify_stem(file_path.stem)
+        families[family] += 1
+        if family == "conforming":
+            continue
+
+        relative_path = file_path.relative_to(root.parent)
+        top_dirs[str(relative_path.parent)] += 1
+        offenders.append(
+            {
+                "path": str(relative_path),
+                "family": family,
+                "nearest_named_parent": nearest_named_parent(file_path.parent, root),
+            }
+        )
+
+    return {
+        "root": str(root),
+        "total_cpp_files": len(files),
+        "conforming_cpp_files": families["conforming"],
+        "nonconforming_cpp_files": len(offenders),
+        "family_counts": dict(families),
+        "top_offender_directories": top_dirs.most_common(25),
+        "offenders": offenders,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Audit BrainGenix-ERS C++ filenames against the CONTRIBUTING.md ERS_* filename rule."
+    )
+    parser.add_argument(
+        "--source-root",
+        default=Path(__file__).resolve().parents[1] / "Source",
+        type=Path,
+        help="Source tree root to scan.",
+    )
+    parser.add_argument(
+        "--write-json",
+        type=Path,
+        help="Optional path to write the JSON audit report to.",
+    )
+    parser.add_argument(
+        "--show-offenders",
+        type=int,
+        default=50,
+        help="How many offender entries to include in the stdout summary.",
+    )
+    args = parser.parse_args()
+
+    report = scan_cpp_files(args.source_root.resolve())
+    if args.write_json:
+        args.write_json.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+
+    summary = {
+        "root": report["root"],
+        "total_cpp_files": report["total_cpp_files"],
+        "conforming_cpp_files": report["conforming_cpp_files"],
+        "nonconforming_cpp_files": report["nonconforming_cpp_files"],
+        "family_counts": report["family_counts"],
+        "top_offender_directories": report["top_offender_directories"],
+        "sample_offenders": report["offenders"][: args.show_offenders],
+    }
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fixes #464.

This does not attempt a risky repo-wide rename in one patch. Instead, it adds the audit tooling and phased plan needed to make the filename refactor mechanical and reviewable.

Included in this patch:

- adds `Tools/AuditCppFileNames.py` to scan `Source/` and report C++ files that do not match the literal `ERS_*` filename rule from `CONTRIBUTING.md`
- adds `Docs/CppFilenameRefactorPlan.md` with the current snapshot, largest offender directories, and a phased migration order

Intentionally not included yet:

- mass file renames
- include-path rewrites
- CMake file-list churn across the tree

Verification:

- `python3 Tools/AuditCppFileNames.py --show-offenders 3`
- `git diff --check` passed for the touched files

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.