### PR TITLE
Add first-pass Cassandra sandbox

### DIFF
--- a/Sandbox/Cassandra/README.md
+++ b/Sandbox/Cassandra/README.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD013 MD043 -->
+
 # Apache Cassandra Sandbox
 
 This directory provides a first-pass local Cassandra sandbox for BrainGenix-ERS data-model experiments.

--- a/Sandbox/Cassandra/README.md
+++ b/Sandbox/Cassandra/README.md
@@ -1,0 +1,63 @@
+# Apache Cassandra Sandbox
+
+This directory provides a first-pass local Cassandra sandbox for BrainGenix-ERS data-model experiments.
+
+It is intentionally separate from the current runtime engine path. The goal is to make issue `#461` reviewable without pretending that the engine already has a Cassandra-backed IOSubsystem implementation.
+
+## Included
+
+- `docker-compose.yml`: single-node Cassandra sandbox pinned to the official `cassandra:5.0` image
+- `schema/00_braingenix_ers_sandbox.cql`: first-pass keyspace and denormalized tables for scene metadata plus per-scene objects
+- `queries/01_smoke_test.cql`: sample inserts and reads that exercise the sandbox schema
+
+## Prerequisites
+
+- Docker Engine or Docker Desktop
+- Docker Compose v2 (`docker compose ...`)
+
+## Start The Sandbox
+
+From this directory:
+
+```bash
+docker compose up -d
+```
+
+The official Cassandra image does not accept CQL connections until initialization completes, so wait until the container is healthy or its logs show that CQL clients are listening.
+
+## Open `cqlsh`
+
+```bash
+docker compose exec cassandra cqlsh
+```
+
+## Load The ERS Sandbox Schema
+
+From inside `cqlsh`:
+
+```sql
+SOURCE '/workspace/schema/00_braingenix_ers_sandbox.cql';
+```
+
+To run the sample inserts and queries afterward:
+
+```sql
+SOURCE '/workspace/queries/01_smoke_test.cql';
+```
+
+## Reset
+
+```bash
+docker compose down -v
+```
+
+## Notes
+
+- This sandbox is for schema and connector experimentation only.
+- It does not yet integrate with `bg-ers-iosubsystem`, `ERS_ProjectManager`, or the live scene loader.
+- The tables are intentionally denormalized around likely read paths so follow-up connector work has a concrete starting point.
+
+## References
+
+- Docker Official Image for Cassandra: <https://hub.docker.com/_/cassandra>
+- Apache Cassandra `cqlsh` documentation: <https://cassandra.apache.org/doc/stable/cassandra/managing/tools/cqlsh.html>

--- a/Sandbox/Cassandra/docker-compose.yml
+++ b/Sandbox/Cassandra/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  cassandra:
+    image: cassandra:5.0
+    container_name: braingenix-ers-cassandra-sandbox
+    environment:
+      CASSANDRA_CLUSTER_NAME: BrainGenixERS-Sandbox
+      CASSANDRA_DC: dc1
+      CASSANDRA_RACK: rack1
+      MAX_HEAP_SIZE: 512M
+      HEAP_NEWSIZE: 128M
+    ports:
+      - "9042:9042"
+    volumes:
+      - cassandra-data:/var/lib/cassandra
+      - ./schema:/workspace/schema:ro
+      - ./queries:/workspace/queries:ro
+    healthcheck:
+      test: ["CMD-SHELL", "cqlsh -e \"DESCRIBE KEYSPACES\" || exit 1"]
+      interval: 20s
+      timeout: 10s
+      retries: 15
+      start_period: 90s
+
+volumes:
+  cassandra-data:

--- a/Sandbox/Cassandra/queries/01_smoke_test.cql
+++ b/Sandbox/Cassandra/queries/01_smoke_test.cql
@@ -1,0 +1,71 @@
+USE braingenix_ers_sandbox;
+
+INSERT INTO scene_metadata (
+  scene_id,
+  scene_name,
+  scene_path,
+  scene_format_version,
+  active_scene_camera_index,
+  created_at,
+  updated_at
+) VALUES (
+  11111111-1111-1111-1111-111111111111,
+  'Sandbox Scene',
+  '/Sandbox/Scenes/SandboxScene.yaml',
+  6,
+  0,
+  toTimestamp(now()),
+  toTimestamp(now())
+);
+
+INSERT INTO scene_objects_by_scene (
+  scene_id,
+  scene_object_index,
+  scene_object_id,
+  object_type,
+  object_label,
+  object_group,
+  backing_index,
+  payload_json
+) VALUES (
+  11111111-1111-1111-1111-111111111111,
+  0,
+  22222222-2222-2222-2222-222222222222,
+  'Model',
+  '[M] TestCube',
+  'Sandbox',
+  0,
+  '{"ModelPath":"Assets/TestCube","Position":[0.0,0.0,0.0]}'
+);
+
+INSERT INTO models_by_name (
+  model_name,
+  model_id,
+  asset_path,
+  scene_id,
+  max_texture_level,
+  target_texture_level_ram,
+  target_texture_level_vram,
+  payload_json
+) VALUES (
+  'TestCube',
+  33333333-3333-3333-3333-333333333333,
+  'Assets/TestCube',
+  11111111-1111-1111-1111-111111111111,
+  4,
+  2,
+  1,
+  '{"HasTransparency":false}'
+);
+
+SELECT scene_name, scene_format_version, active_scene_camera_index
+FROM scene_metadata
+WHERE scene_id = 11111111-1111-1111-1111-111111111111;
+
+SELECT scene_object_index, object_type, object_label
+FROM scene_objects_by_scene
+WHERE scene_id = 11111111-1111-1111-1111-111111111111;
+
+SELECT model_name, asset_path, max_texture_level
+FROM models_by_name
+WHERE model_name = 'TestCube';

--- a/Sandbox/Cassandra/schema/00_braingenix_ers_sandbox.cql
+++ b/Sandbox/Cassandra/schema/00_braingenix_ers_sandbox.cql
@@ -1,0 +1,41 @@
+CREATE KEYSPACE IF NOT EXISTS braingenix_ers_sandbox
+WITH replication = {
+  'class': 'SimpleStrategy',
+  'replication_factor': 1
+};
+
+USE braingenix_ers_sandbox;
+
+CREATE TABLE IF NOT EXISTS scene_metadata (
+  scene_id uuid PRIMARY KEY,
+  scene_name text,
+  scene_path text,
+  scene_format_version bigint,
+  active_scene_camera_index int,
+  created_at timestamp,
+  updated_at timestamp
+);
+
+CREATE TABLE IF NOT EXISTS scene_objects_by_scene (
+  scene_id uuid,
+  scene_object_index bigint,
+  scene_object_id uuid,
+  object_type text,
+  object_label text,
+  object_group text,
+  backing_index bigint,
+  payload_json text,
+  PRIMARY KEY ((scene_id), scene_object_index)
+);
+
+CREATE TABLE IF NOT EXISTS models_by_name (
+  model_name text,
+  model_id uuid,
+  asset_path text,
+  scene_id uuid,
+  max_texture_level int,
+  target_texture_level_ram int,
+  target_texture_level_vram int,
+  payload_json text,
+  PRIMARY KEY ((model_name), model_id)
+);


### PR DESCRIPTION
Fixes #461.

This adds a first-pass local Cassandra sandbox for schema and connector experiments without pretending that the live ERS runtime already has a Cassandra-backed IOSubsystem implementation.

Included in this patch:

- adds `Sandbox/Cassandra/docker-compose.yml` using the official Cassandra image
- adds `Sandbox/Cassandra/schema/00_braingenix_ers_sandbox.cql` with a first-pass ERS-oriented keyspace and denormalized tables
- adds `Sandbox/Cassandra/queries/01_smoke_test.cql` with sample inserts and reads
- adds `Sandbox/Cassandra/README.md` documenting bring-up, schema loading, smoke-test execution, and teardown

Intentionally not included yet:

- a real Cassandra-backed `bg-ers-iosubsystem` implementation
- automated connector tests against this sandbox
- production cluster, replication, or multi-node topology work

Verification:

- reviewed the isolated sandbox files for this patch
- `git diff --check` passed for the touched files
- local `docker compose` / `cqlsh` bring-up is still pending because Docker is not available in this environment

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.