### PR TITLE
Add first-pass macOS build path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: macOS Build
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".gitmodules"
+      - "CMake/**"
+      - "CMakeLists.txt"
+      - "Source/**"
+      - "ThirdParty/**"
+      - "Tools/**"
+  push:
+    branches:
+      - master
+    paths:
+      - ".github/workflows/**"
+      - ".gitmodules"
+      - "CMake/**"
+      - "CMakeLists.txt"
+      - "Source/**"
+      - "ThirdParty/**"
+      - "Tools/**"
+
+permissions:
+  contents: read
+
+jobs:
+  build-macos13:
+    name: Build (macOS 13)
+    runs-on: macos-13
+    timeout-minutes: 120
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        working-directory: Tools
+        run: bash SetupMacOS.sh
+
+      - name: Build ERS
+        working-directory: Tools
+        run: bash Build.sh 2 Release
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: BrainGenix-ERS-macos13
+          path: |
+            Build/
+            Binaries/

--- a/README.md
+++ b/README.md
@@ -182,6 +182,19 @@ Depending on the type of object selected, the window will display different prop
   If some packages are missing on your distro, you'll have to substitute with whatever your distro uses. We try to include as many packages in our codebase as possible via superbuilds, but this isn't always possible or practical.
 
 
+## macOS:
+
+  macOS is not yet a primary development target, but there is now a first-pass setup helper for local native builds on the GitHub mirror path.
+
+  Install Homebrew first, then enter the `Tools` directory and run `bash SetupMacOS.sh` followed by `bash Build.sh [number_of_threads] [build_type]`.
+
+  Example:
+  `bash SetupMacOS.sh`
+  `bash Build.sh 4 Release`
+
+  This path is currently intended as an early portability/build-validation slice rather than a fully supported shipping workflow.
+
+
 ## Windows:
 
   At this time, we're not working on native Windows builds since we are working on cross-compiling for Windows platforms from Linux. This will allow us to simplify our build infrastructure significantly. Therefore, ***the following section is out of date and may not work!***

--- a/Tools/SetupMacOS.sh
+++ b/Tools/SetupMacOS.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -euo pipefail
+
+
+if ! command -v brew >/dev/null 2>&1; then
+    echo "Homebrew is required to build ERS on macOS. Install it first from https://brew.sh/."
+    exit 1
+fi
+
+
+echo "Updating Homebrew package metadata"
+brew update
+
+
+BREW_DEPS=(
+    git
+    wget
+    cmake
+    pkgconf
+    autoconf
+    automake
+    libtool
+    bison
+    flex
+    ninja
+)
+
+echo "Installing Homebrew dependencies: ${BREW_DEPS[*]}"
+brew install "${BREW_DEPS[@]}"
+
+
+echo "Updating submodules"
+git submodule update --init
+
+
+echo "Setting up vcpkg"
+./../ThirdParty/vcpkg/bootstrap-vcpkg.sh
+
+echo "Done, you can now run Build.sh"


### PR DESCRIPTION
Fixes #456.

This adds a first-pass macOS-native build path without claiming full cross-compilation or shipping support in one patch.

Included in this patch:

- adds `Tools/SetupMacOS.sh` to install the basic Homebrew build prerequisites and bootstrap `vcpkg`
- adds a `build-macos13` GitHub Actions job that runs the new setup helper and then builds ERS in `Release`
- updates the README with an explicit macOS build section using the new helper

Intentionally not included yet:

- Linux-to-macOS cross-compilation
- packaging or signing for macOS releases
- a complete support matrix for every optional dependency on macOS

Verification:

- `bash -n Tools/SetupMacOS.sh`
- `git diff --check` passed for the touched files
- GitHub Actions runtime verification is still pending until the PR workflow runs on GitHub-hosted macOS

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.