### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: CI
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".gitmodules"
+      - "CMake/**"
+      - "CMakeLists.txt"
+      - "CI/**"
+      - "Docs/**"
+      - "Source/**"
+      - "ThirdParty/**"
+      - "Tools/**"
+  push:
+    branches:
+      - master
+    paths:
+      - ".github/workflows/**"
+      - ".gitmodules"
+      - "CMake/**"
+      - "CMakeLists.txt"
+      - "CI/**"
+      - "Docs/**"
+      - "Source/**"
+      - "ThirdParty/**"
+      - "Tools/**"
+
+permissions:
+  contents: read
+
+jobs:
+  build-ubuntu2204:
+    name: Build (Ubuntu 22.04)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        working-directory: Tools
+        run: bash Setup.sh
+
+      - name: Build ERS
+        working-directory: Tools
+        run: bash Build.sh 2
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: BrainGenix-ERS-ubuntu2204
+          path: |
+            Build/
+            Binaries/
+
+  doxygen:
+    name: Doxygen
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install doxygen
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y doxygen
+
+      - name: Generate docs
+        working-directory: Tools/Docs
+        run: bash GenerateDoxygen.sh
+
+      - name: Upload doxygen artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: BrainGenix-ERS-doxygen
+          path: Docs/Doxygen/Generated/


### PR DESCRIPTION
Fixes #457.

This adds a first-pass GitHub Actions workflow for the GitHub mirror.

Included in this patch:

- adds an Ubuntu 22.04 build job that mirrors the existing GitLab build helper flow
- checks out submodules recursively so the `ThirdParty/vcpkg` toolchain is available
- preserves the existing cwd-sensitive helper-script behavior by running `Setup.sh` and `Build.sh` from `Tools/`
- adds a Doxygen job that runs the existing docs helper from `Tools/Docs`
- uploads both the build outputs and generated Doxygen artifacts

Verification:

- reviewed the isolated workflow content for the Ubuntu build and Doxygen jobs
- `git diff --check` passed for the workflow file
- remote workflow execution is pending on GitHub after PR creation

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.