### PR TITLE
Add first-pass EGL build support

### DIFF
--- a/CMake/BuildUtils/EGL.cmake
+++ b/CMake/BuildUtils/EGL.cmake
@@ -1,0 +1,24 @@
+##########################
+# Builds Library For ERS #
+##########################
+
+option(ENABLE_EGL "Configure EGL support for future off-screen rendering targets" ON)
+
+ERSBuildLogger(${Green} "Configuring EGL Support")
+if (ENABLE_EGL AND UNIX AND NOT APPLE)
+
+    find_path(EGL_INCLUDE_DIR NAMES EGL/egl.h)
+    find_library(EGL_LIBRARY NAMES EGL)
+
+    if ((NOT EGL_INCLUDE_DIR) OR (NOT EGL_LIBRARY))
+        message(FATAL_ERROR "ENABLE_EGL is ON but EGL headers or the EGL library were not found. Install libegl1-mesa-dev or reconfigure with -DENABLE_EGL=OFF.")
+    endif()
+
+    add_library(ERS_EGL INTERFACE)
+    target_include_directories(ERS_EGL INTERFACE ${EGL_INCLUDE_DIR})
+    target_link_libraries(ERS_EGL INTERFACE ${EGL_LIBRARY})
+
+    ERSBuildLogger(${BoldGreen} "Finished Configuring EGL Support")
+else()
+    ERSBuildLogger(${Yellow} "Skipping EGL Support On This Platform")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ include(${CMAKE_SCRIPTS_DIR}/CompileTimeStamp/CompileTimeStamp.cmake)
 # Include Package Addition Scripts
 include(${CMAKE_BUILD_UTILS_DIR}/Backward.cmake)
 include(${CMAKE_BUILD_UTILS_DIR}/Threads.cmake)
+include(${CMAKE_BUILD_UTILS_DIR}/EGL.cmake)
 include(${CMAKE_BUILD_UTILS_DIR}/Glad.cmake)
 include(${CMAKE_BUILD_UTILS_DIR}/GLM.cmake)
 include(${CMAKE_BUILD_UTILS_DIR}/ImGui.cmake)
@@ -238,6 +239,9 @@ target_link_libraries("ERS"
 
     Renderer
 )
+if (TARGET ERS_EGL)
+    target_link_libraries("ERS" ERS_EGL)
+endif()
 target_include_directories("ERS" PRIVATE ${SRC_DIR})
 
 # Run Configuration On EditorAssetBundle

--- a/Tools/Setup.sh
+++ b/Tools/Setup.sh
@@ -30,9 +30,12 @@ GLFW_DEPS="libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev"
 # GLUT Deps
 GLUT_DEPS="libxi-dev libgl1-mesa-dev libglu1-mesa-dev mesa-common-dev libxrandr-dev libxxf86vm-dev"
 
+# EGL Deps
+EGL_DEPS="libegl1-mesa-dev"
+
 
 # Install Everything
-INSTALL_COMMAND="$APT_COMMAND_PREFIX apt install $VCPKG_DEPS $COMPILER_DEPS $GLFW_DEPS $GLUT_DEPS -y"
+INSTALL_COMMAND="$APT_COMMAND_PREFIX apt install $VCPKG_DEPS $COMPILER_DEPS $GLFW_DEPS $GLUT_DEPS $EGL_DEPS -y"
 echo "Running Install Command: $INSTALL_COMMAND"
 $INSTALL_COMMAND || exit 1
 


### PR DESCRIPTION
Fixes #467.

Addresses #467.

This adds a first-pass EGL dependency path to the top-level build so later off-screen rendering work does not need to start from zero.

Included in this patch:

- adds `CMake/BuildUtils/EGL.cmake` to detect EGL headers and the EGL system library on supported Unix platforms
- wires the top-level `ERS` target to the new `ERS_EGL` interface target when EGL support is enabled
- updates `Tools/Setup.sh` to install `libegl1-mesa-dev` so the documented Linux setup path can satisfy the new dependency

Notes:

- this is intentionally build-system plumbing only; it does not claim to implement the later EGL rendering issues yet
- the patch is focused on making EGL available to the existing Linux-first build so `#468` and `#469` have a stable dependency entry point

Verification:

- configured a small temporary CMake project that includes `CMake/BuildUtils/EGL.cmake`
- `bash -n Tools/Setup.sh`
- `git diff --check` passed for the touched files
- full ERS configure/build remains pending because the full ERS dependency stack is not installed in this environment

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.