### PR TITLE
Add first-pass OpenXR build plumbing

### DIFF
--- a/CMake/BuildUtils/OpenXR.cmake
+++ b/CMake/BuildUtils/OpenXR.cmake
@@ -1,0 +1,43 @@
+#############################
+# Builds OpenXR Integration #
+#############################
+
+ERSBuildLogger(${Green} "Configuring OpenXR Support")
+option(ENABLE_OPENXR "Build ERS with OpenXR loader/header plumbing for future XR integration" OFF)
+
+add_library(ERS_OpenXR INTERFACE)
+
+if (ENABLE_OPENXR)
+    find_package(OpenXR CONFIG QUIET)
+    if ((NOT TARGET OpenXR::openxr_loader) AND (NOT TARGET OpenXR::headers) AND (NOT TARGET OpenXR::Loader))
+        find_package(OpenXR QUIET COMPONENTS loader headers)
+    endif()
+
+    if ((NOT TARGET OpenXR::openxr_loader) AND TARGET OpenXR::Loader)
+        add_library(OpenXR::openxr_loader INTERFACE IMPORTED)
+        set_target_properties(OpenXR::openxr_loader PROPERTIES
+            INTERFACE_LINK_LIBRARIES "OpenXR::Loader")
+    endif()
+
+    if ((NOT TARGET OpenXR::headers) AND TARGET OpenXR::Headers)
+        add_library(OpenXR::headers INTERFACE IMPORTED)
+        set_target_properties(OpenXR::headers PROPERTIES
+            INTERFACE_LINK_LIBRARIES "OpenXR::Headers")
+    endif()
+
+    if (TARGET OpenXR::openxr_loader)
+        target_link_libraries(ERS_OpenXR INTERFACE OpenXR::openxr_loader)
+        if (TARGET OpenXR::headers)
+            target_link_libraries(ERS_OpenXR INTERFACE OpenXR::headers)
+        endif()
+        target_compile_definitions(ERS_OpenXR INTERFACE ERS_ENABLE_OPENXR)
+        ERSBuildLogger(${Green} "OpenXR support enabled")
+    else()
+        message(WARNING "ENABLE_OPENXR is ON but the OpenXR loader package was not found. XR build plumbing will remain disabled.")
+        ERSBuildLogger(${Yellow} "OpenXR package not found, support disabled")
+    endif()
+else()
+    ERSBuildLogger(${Green} "OpenXR support disabled, skipping")
+endif()
+
+ERSBuildLogger(${BoldGreen} "Finished Configuring OpenXR Support")

--- a/CMake/FindUtils/FindOpenXR.cmake
+++ b/CMake/FindUtils/FindOpenXR.cmake
@@ -300,7 +300,13 @@ if(OpenXR_headers_FOUND)
         add_library(OpenXR::Headers INTERFACE IMPORTED)
     endif()
     set_target_properties(OpenXR::Headers PROPERTIES
-        INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_oxr_include_dirs}")
+        INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${OPENXR_INCLUDE_DIRS}")
+
+    if(NOT TARGET OpenXR::headers)
+        add_library(OpenXR::headers INTERFACE IMPORTED)
+    endif()
+    set_target_properties(OpenXR::headers PROPERTIES
+        INTERFACE_LINK_LIBRARIES "OpenXR::Headers")
 
     # This target just provides the headers, without any prototypes.
     # Finding and loading the loader at runtime is your problem.
@@ -332,4 +338,10 @@ if(OpenXR_loader_FOUND AND OpenXR_headers_FOUND)
         IMPORTED_LINK_INTERFACE_LANGUAGES "C"
         IMPORTED_LOCATION "${OPENXR_loader_LIBRARY}"
         INTERFACE_LINK_LIBRARIES "${_oxr_loader_interface_libs}")
+
+    if(NOT TARGET OpenXR::openxr_loader)
+        add_library(OpenXR::openxr_loader INTERFACE IMPORTED)
+    endif()
+    set_target_properties(OpenXR::openxr_loader PROPERTIES
+        INTERFACE_LINK_LIBRARIES "OpenXR::Loader")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ set(CMAKE_FIND_UTILS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/CMake/FindUtils")
 set(CMAKE_SCRIPTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/CMake/Scripts")
 set(CMAKE_UTILS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/CMake")
 set(CMAKE_ASSETS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/EditorAssets")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_FIND_UTILS_DIR}")
 SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 set(PROJECT_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR})
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
@@ -88,6 +89,7 @@ include(${CMAKE_SCRIPTS_DIR}/CompileTimeStamp/CompileTimeStamp.cmake)
 # Include Package Addition Scripts
 include(${CMAKE_BUILD_UTILS_DIR}/Backward.cmake)
 include(${CMAKE_BUILD_UTILS_DIR}/Threads.cmake)
+include(${CMAKE_BUILD_UTILS_DIR}/OpenXR.cmake)
 include(${CMAKE_BUILD_UTILS_DIR}/Glad.cmake)
 include(${CMAKE_BUILD_UTILS_DIR}/GLM.cmake)
 include(${CMAKE_BUILD_UTILS_DIR}/ImGui.cmake)
@@ -238,6 +240,7 @@ target_link_libraries("ERS"
 
     Renderer
 )
+target_link_libraries("ERS" ERS_OpenXR)
 target_include_directories("ERS" PRIVATE ${SRC_DIR})
 
 # Run Configuration On EditorAssetBundle

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,9 +11,8 @@
     "platform-folders",
     "ghc-filesystem",
     "infoware",
+    "openxr-loader",
     "lua",
-
     "bg-ers-iosubsystem"
-
   ]
 }


### PR DESCRIPTION
Fixes #88.

This adds a first-pass OpenXR integration slice at the build-system level without yet adding runtime XR rendering or input code.

Included in this patch:

- adds `openxr-loader` to the vcpkg manifest so the loader can be resolved through the existing dependency flow
- adds `CMake/BuildUtils/OpenXR.cmake` with an `ENABLE_OPENXR` option and a lightweight `ERS_OpenXR` interface target
- wires the top-level build to use OpenXR through either a modern package config or the repo-local `FindOpenXR.cmake` fallback
- fixes the repo-local `FindOpenXR.cmake` header include propagation and adds compatibility aliases for the official `OpenXR::headers` / `OpenXR::openxr_loader` target names
- intentionally keeps the first slice narrow: no runtime OpenXR session creation, swapchains, controller actions, or editor XR mode yet

Verification:

- configured a small temporary CMake project that includes `CMake/BuildUtils/OpenXR.cmake`
- `python3 -m json.tool vcpkg.json`
- `git diff --check` passed for the touched files
- full ERS configure/build remains pending because the full ERS dependency stack is not installed in this environment

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.