### PR TITLE
Add first-pass Bullet build plumbing

### DIFF
--- a/CMake/BuildUtils/Bullet.cmake
+++ b/CMake/BuildUtils/Bullet.cmake
@@ -1,0 +1,45 @@
+############################
+# Builds Bullet Integration #
+############################
+
+ERSBuildLogger(${Green} "Configuring Bullet Physics Support")
+option(ENABLE_BULLET "Build ERS with Bullet physics dependency plumbing for future scene integration" OFF)
+
+add_library(ERS_Bullet INTERFACE)
+
+if (ENABLE_BULLET)
+    find_package(Bullet CONFIG QUIET)
+
+    set(ERS_BULLET_TARGETS "")
+    if (DEFINED BULLET_LIBRARIES AND NOT "${BULLET_LIBRARIES}" STREQUAL "")
+        list(APPEND ERS_BULLET_TARGETS ${BULLET_LIBRARIES})
+    else()
+        foreach(ERS_BULLET_TARGET IN ITEMS
+            BulletDynamics
+            BulletCollision
+            LinearMath
+            BulletSoftBody
+            BulletInverseDynamics
+            Bullet3Common
+            Bullet3Dynamics
+        )
+            if (TARGET ${ERS_BULLET_TARGET})
+                list(APPEND ERS_BULLET_TARGETS ${ERS_BULLET_TARGET})
+            endif()
+        endforeach()
+    endif()
+
+    if (ERS_BULLET_TARGETS)
+        list(REMOVE_DUPLICATES ERS_BULLET_TARGETS)
+        target_link_libraries(ERS_Bullet INTERFACE ${ERS_BULLET_TARGETS})
+        target_compile_definitions(ERS_Bullet INTERFACE ERS_ENABLE_BULLET)
+        ERSBuildLogger(${Green} "Bullet physics support enabled")
+    else()
+        message(WARNING "ENABLE_BULLET is ON but the Bullet package was not found or did not expose usable targets. Physics build plumbing will remain disabled.")
+        ERSBuildLogger(${Yellow} "Bullet package not found, support disabled")
+    endif()
+else()
+    ERSBuildLogger(${Green} "Bullet physics support disabled, skipping")
+endif()
+
+ERSBuildLogger(${BoldGreen} "Finished Configuring Bullet Physics Support")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ include(${CMAKE_SCRIPTS_DIR}/CompileTimeStamp/CompileTimeStamp.cmake)
 # Include Package Addition Scripts
 include(${CMAKE_BUILD_UTILS_DIR}/Backward.cmake)
 include(${CMAKE_BUILD_UTILS_DIR}/Threads.cmake)
+include(${CMAKE_BUILD_UTILS_DIR}/Bullet.cmake)
 include(${CMAKE_BUILD_UTILS_DIR}/Glad.cmake)
 include(${CMAKE_BUILD_UTILS_DIR}/GLM.cmake)
 include(${CMAKE_BUILD_UTILS_DIR}/ImGui.cmake)
@@ -238,6 +239,7 @@ target_link_libraries("ERS"
 
     Renderer
 )
+target_link_libraries("ERS" ERS_Bullet)
 target_include_directories("ERS" PRIVATE ${SRC_DIR})
 
 # Run Configuration On EditorAssetBundle

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,9 +11,8 @@
     "platform-folders",
     "ghc-filesystem",
     "infoware",
+    "bullet3",
     "lua",
-
     "bg-ers-iosubsystem"
-
   ]
 }


### PR DESCRIPTION
Fixes #251.

This adds a first-pass optional Bullet dependency path to ERS without pretending to solve the full physics integration in one patch.

Included in this patch:

- adds `bullet3` to the vcpkg manifest
- adds `CMake/BuildUtils/Bullet.cmake` with an optional `ERS_Bullet` interface target
- enables `ERS_ENABLE_BULLET` only when Bullet is explicitly requested and usable CMake targets are found
- links the top-level `ERS` target against `ERS_Bullet` so later physics work can build on a stable dependency hook

Intentionally not included yet:

- Bullet rigid-body world setup
- scene/editor controls for physics ownership
- script-facing physics parameter plumbing

Verification:

- configured a small temporary CMake project that includes `CMake/BuildUtils/Bullet.cmake`
- `python3 -m json.tool vcpkg.json`
- `git diff --check` passed for the touched files
- full ERS configure/build remains pending because the full ERS dependency stack is not installed in this environment

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.