### PR TITLE
Add popup warning queue and modal

### DIFF
--- a/Source/Core/Editor/GUI.cpp
+++ b/Source/Core/Editor/GUI.cpp
@@ -109,6 +109,7 @@ void GUISystem::UpdateGUI() {
 
     // Updates all the windows, draws their content if enabled
     WindowManager_->UpdateAllWindows();
+    UpdateWarningPopup();
 
 
 }
@@ -126,4 +127,36 @@ void GUISystem::UpdateFrame() {
     ImGui::Render();
     ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
     
+}
+
+void GUISystem::UpdateWarningPopup() {
+
+    if (!WarningPopupOpen_ && SystemUtils_->HasPopupWarning()) {
+        ERS_STRUCT_SystemUtils::PopupWarning Warning = SystemUtils_->PopPopupWarning();
+        ActiveWarningTitle_ = Warning.Title.empty() ? "ERS Warning" : Warning.Title;
+        ActiveWarningMessage_ = Warning.Message;
+        WarningPopupOpen_ = true;
+        ImGui::OpenPopup("ERS Warning");
+    }
+
+    bool KeepOpen = WarningPopupOpen_;
+    if (ImGui::BeginPopupModal("ERS Warning", &KeepOpen, ImGuiWindowFlags_AlwaysAutoResize)) {
+        ImGui::Text("%s", ActiveWarningTitle_.c_str());
+        ImGui::Separator();
+        ImGui::TextWrapped("%s", ActiveWarningMessage_.c_str());
+        ImGui::Spacing();
+
+        if (ImGui::Button("Acknowledge")) {
+            WarningPopupOpen_ = false;
+            ActiveWarningTitle_ = "ERS Warning";
+            ActiveWarningMessage_.clear();
+            ImGui::CloseCurrentPopup();
+        }
+
+        ImGui::EndPopup();
+    } else if (!KeepOpen) {
+        WarningPopupOpen_ = false;
+        ActiveWarningTitle_ = "ERS Warning";
+        ActiveWarningMessage_.clear();
+    }
 }

--- a/Source/Core/Editor/GUI.h
+++ b/Source/Core/Editor/GUI.h
@@ -60,6 +60,9 @@ private:
     ERS_CLASS_SceneManager*           SceneManager_   = nullptr; /**<Scene Manager Instance Pointer*/
     ERS_CLASS_VisualRenderer*         VisualRenderer_ = nullptr; /**<Pointer to visual renderer for viewport modification*/
     ERS_STRUCT_HumanInputDeviceUtils* HIDUtils_       = nullptr; /**<Pointer To Human Device Utils Struct*/
+    std::string ActiveWarningTitle_   = "ERS Warning"; /**<Title of the popup warning currently displayed.*/
+    std::string ActiveWarningMessage_; /**<Body of the popup warning currently displayed.*/
+    bool WarningPopupOpen_            = false; /**<Tracks if a warning popup is currently active.*/
 
     std::unique_ptr<ERS_CLASS_FontManager>        FontManager_;        /**<Pointer To FontManager Instance*/
     std::unique_ptr<ERS_CLASS_UserProfileManager> UserProfileManager_; /**<Pointer To User Profile Manager Instance*/
@@ -114,4 +117,8 @@ public:
      * 
      */
     void DeferredFrameUpdate();
+
+private:
+
+    void UpdateWarningPopup();
 };

--- a/Source/Core/Structures/ERS_STRUCT_SystemUtils/SystemUtils.h
+++ b/Source/Core/Structures/ERS_STRUCT_SystemUtils/SystemUtils.h
@@ -6,6 +6,10 @@
 
 // Standard Libraries (BG convention: use <> instead of "")
 #include <memory.h>
+#include <deque>
+#include <mutex>
+#include <string>
+#include <vector>
 
 // Third-Party Libraries (BG convention: use <> instead of "")
 #include <yaml-cpp/yaml.h>
@@ -33,6 +37,11 @@
  */
 struct ERS_STRUCT_SystemUtils {
 
+    struct PopupWarning {
+        std::string Title;
+        std::string Message;
+    };
+
 
     std::vector<std::pair<std::string, std::string>> Arguments_; /**<Pair of key and value arguments used to launch the program*/
     std::string ArgumentString_; /**<String version of the argument pair*/
@@ -52,6 +61,25 @@ struct ERS_STRUCT_SystemUtils {
 
     int RenderWidth_ = 0; /**<Width of the display being rendered to (if using a window, this is the size of the window)*/
     int RenderHeight_ = 0; /**<Height of the display being rendered to (if using a window, this is the size of the window)*/
+    std::deque<PopupWarning> PopupWarnings_; /**<Queued warning dialogs waiting to be displayed by the GUI.*/
+    std::mutex PopupWarningsMutex_; /**<Protects PopupWarnings_ when warnings are queued from multiple systems.*/
+
+    inline void QueuePopupWarning(const std::string& Title, const std::string& Message) {
+        std::lock_guard<std::mutex> Lock(PopupWarningsMutex_);
+        PopupWarnings_.push_back({Title, Message});
+    }
+
+    inline bool HasPopupWarning() {
+        std::lock_guard<std::mutex> Lock(PopupWarningsMutex_);
+        return !PopupWarnings_.empty();
+    }
+
+    inline PopupWarning PopPopupWarning() {
+        std::lock_guard<std::mutex> Lock(PopupWarningsMutex_);
+        PopupWarning Warning = PopupWarnings_.front();
+        PopupWarnings_.pop_front();
+        return Warning;
+    }
     
 
 


### PR DESCRIPTION
Fixes #107.

This adds a simple popup warning API that editor systems can use to surface warnings through a modal dialog.

Included in this patch:

- adds a thread-safe popup warning queue to `ERS_STRUCT_SystemUtils`
- lets `GUISystem` pull queued warnings and show them through a modal popup
- keeps the popup API minimal so existing subsystems can call it without new GUI dependencies

Verification:

- isolated the popup-warning changes from unrelated GUI work by rebuilding the patch from `origin/master`
- `git diff --no-index --check` passed for the isolated files
- full ERS build/runtime verification remains pending because the full ERS dependency stack is not installed in this environment

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.