### PR TITLE
Improve cooperative shutdown for worker threads

### DIFF
--- a/Source/Core/Loader/ERS_ModelLoader/ModelLoader.cpp
+++ b/Source/Core/Loader/ERS_ModelLoader/ModelLoader.cpp
@@ -30,6 +30,7 @@ ERS_CLASS_ModelLoader::ERS_CLASS_ModelLoader(ERS_STRUCT_SystemUtils* SystemUtils
     for (int i = 0; i < MaxModelLoadingThreads; i++) {
         SystemUtils_->Logger_->Log(std::string(std::string("Creating Worker Thread ") + std::to_string(i)).c_str(), 3);
         WorkerThreads_.push_back(std::thread(&ERS_CLASS_ModelLoader::WorkerThread, this, i));
+        ActiveWorkerCount_ += 1;
     }
 
     //SystemUtils_->Logger_->Log("Creating Reference Loading Thread", 5);
@@ -41,40 +42,31 @@ ERS_CLASS_ModelLoader::ERS_CLASS_ModelLoader(ERS_STRUCT_SystemUtils* SystemUtils
 ERS_CLASS_ModelLoader::~ERS_CLASS_ModelLoader() {
 
     SystemUtils_->Logger_->Log("ModelLoader Destructor Called", 6);
-    FreeImage_DeInitialise();
-
-
 
     // Shutdown Threads
     SystemUtils_->Logger_->Log("Sending Join Command To Worker Threads", 5);
-    BlockThread_.lock();
-    ExitThreads_ = true;
-    BlockThread_.unlock();
+    {
+        std::lock_guard<std::mutex> Lock(BlockThread_);
+        ExitThreads_ = true;
+    }
+    WorkQueueCondition_.notify_all();
+
+    {
+        std::unique_lock<std::mutex> Lock(BlockThread_);
+        bool WorkersStopped = WorkerShutdownCondition_.wait_for(Lock, std::chrono::seconds(2), [this]() {
+            return ActiveWorkerCount_ == 0;
+        });
+        if (!WorkersStopped) {
+            SystemUtils_->Logger_->Log("Model loading threads did not stop within 2 seconds. ERS will keep waiting for a clean shutdown instead of forcing termination.", 9);
+        }
+    }
 
     SystemUtils_->Logger_->Log("Joining Worker Threads", 6);
     for (int i = 0; (long)i < (long)WorkerThreads_.size(); i++) {
         SystemUtils_->Logger_->Log(std::string(std::string("Joining Worker Thread ") + std::to_string(i)).c_str(), 3);
-		if (WorkerThreads_[i].joinable()) {
-		
-			// Wait for the thread to finish for up to 10 seconds
-			for (int k = 0; k < 100 && WorkerThreads_[i].joinable(); ++k) {
-				if (WorkerThreads_[i].joinable()) 
-					WorkerThreads_[i].join();
-				else
-					break;
-				std::this_thread::sleep_for(std::chrono::milliseconds(1));
-			}			
-
-			//If the thread is still running, terminate it
-			if (WorkerThreads_[i].joinable()) {
-				WorkerThreads_[i].detach();
-
-
-			if (WorkerThreads_[i].joinable()) 
-				std::terminate();
-			}
-		}
-		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        if (WorkerThreads_[i].joinable()) {
+            WorkerThreads_[i].join();
+        }
     }
     SystemUtils_->Logger_->Log("Finished Joining Worker Threads", 6);
 
@@ -87,6 +79,7 @@ ERS_CLASS_ModelLoader::~ERS_CLASS_ModelLoader() {
     // ModelRefrenceThread_.join();
     // SystemUtils_->Logger_->Log("Finished Joining Reference Loader Thread", 5);
 
+    FreeImage_DeInitialise();
 
 }
 
@@ -95,45 +88,34 @@ void ERS_CLASS_ModelLoader::WorkerThread(int WorkerThreadNumber) {
     std::string ThreadName = std::string("GLT-") + std::to_string(WorkerThreadNumber);
     SetThreadName(ThreadName);
 
-    bool ThreadShouldRun = true;
-    while (ThreadShouldRun) {
+    while (true) {
+        std::shared_ptr<ERS_STRUCT_Model> WorkItem;
+        long WorkID = -1;
 
-        // Acquire Check Lock
-        BlockThread_.lock();
-        if (ExitThreads_) {
-            ThreadShouldRun = false;
-            BlockThread_.unlock();
-        } else {
+        {
+            std::unique_lock<std::mutex> Lock(BlockThread_);
+            WorkQueueCondition_.wait(Lock, [this]() {
+                return ExitThreads_ || !WorkItems_.empty();
+            });
 
-            // Check If Items In Work Queue
-            int Size = WorkItems_.size();
-            if (Size > 0) {
-
-                // Get Item, Remove From Queue, Unlock
-                std::shared_ptr<ERS_STRUCT_Model> WorkItem = WorkItems_[0];
-                long WorkID = WorkIDs_[0];
-
-
-                WorkItems_.erase(WorkItems_.begin());
-                WorkIDs_.erase(WorkIDs_.begin());
-
-
-                BlockThread_.unlock();
-
-                // Process Item
-                LoadModel(WorkID, WorkItem);
-
-            } else {
-                
-                // No Work Items, Unlock Mutex, Sleep Thread
-                BlockThread_.unlock();
-                std::this_thread::sleep_for(std::chrono::milliseconds(20));
-
+            if (ExitThreads_) {
+                break;
             }
+
+            WorkItem = WorkItems_[0];
+            WorkID = WorkIDs_[0];
+            WorkItems_.erase(WorkItems_.begin());
+            WorkIDs_.erase(WorkIDs_.begin());
         }
 
-
+        LoadModel(WorkID, WorkItem);
     }
+
+    {
+        std::lock_guard<std::mutex> Lock(BlockThread_);
+        ActiveWorkerCount_ -= 1;
+    }
+    WorkerShutdownCondition_.notify_all();
 
 }
 
@@ -165,13 +147,12 @@ void ERS_CLASS_ModelLoader::AddModelToLoadingQueue(long AssetID, std::shared_ptr
     SystemUtils_->Logger_->Log(std::string(std::string("Adding Model '") + std::to_string(AssetID) + std::string("' To Load Queue")).c_str(), 4);
 
     // Add To Queue
-    BlockThread_.lock();
-
-    WorkIDs_.push_back(AssetID);
-    WorkItems_.push_back(Model);
-    
-
-    BlockThread_.unlock();
+    {
+        std::lock_guard<std::mutex> Lock(BlockThread_);
+        WorkIDs_.push_back(AssetID);
+        WorkItems_.push_back(Model);
+    }
+    WorkQueueCondition_.notify_one();
 
 }
 

--- a/Source/Core/Loader/ERS_ModelLoader/ModelLoader.h
+++ b/Source/Core/Loader/ERS_ModelLoader/ModelLoader.h
@@ -16,7 +16,9 @@
 #include <assert.h>
 #include <sys/stat.h>
 #include <stdlib.h>
+#include <condition_variable>
 #include <future>
+#include <mutex>
 #include <thread>
 #include <chrono>
 
@@ -82,10 +84,13 @@ private:
 
     std::mutex BlockThread_; /**<Block Threads From Doing Things*/
     std::mutex BlockRefThread_; /**<Lock the ref thread from modifying non-threadsafe vars*/
+    std::condition_variable WorkQueueCondition_; /**<Used to wake worker threads when new work arrives or shutdown begins.*/
+    std::condition_variable WorkerShutdownCondition_; /**<Used to detect when all workers have exited their loop.*/
 
     bool ExitThreads_ = false; /**<Set To True To Make Threads Quit*/
     bool EnableReferenceLoading_ = false; /**<Enable Or Disable Re-Using Assets Instead Of Reloading (Massive Performance Improvement When Enabled)*/
     bool ExitRefThread_ = false; /**Make ref matching thread exit*/
+    int ActiveWorkerCount_ = 0; /**<Tracks the number of loader workers still alive during shutdown.*/
 
 
     /**

--- a/Source/Internal/HardwareInformation/HardwareInformation.cpp
+++ b/Source/Internal/HardwareInformation/HardwareInformation.cpp
@@ -104,6 +104,7 @@ ERS_HardwareInformation::ERS_HardwareInformation(BG::Common::Logger::LoggingSyst
 
     // Launch Thread
     Logger_->Log("Starting Dynamic Information Update Thread", 5);
+    DynamicInfoThreadActive_ = true;
     DynamicUpdateThread_ = SpawnThread();
 
 }
@@ -115,28 +116,25 @@ ERS_HardwareInformation::~ERS_HardwareInformation() {
 
     // Shut Down Dynamic Update Thread
     Logger_->Log("Stopping Dynamic Update Thread", 5);
-    ShouldDynamicInfoThreadRun_ = false;
-	if (DynamicUpdateThread_.joinable()) {
-		// Wait for the thread to finish for up to 10 seconds
-		for (int i = 0; i < 100 && DynamicUpdateThread_.joinable(); ++i) {
-			if (DynamicUpdateThread_.joinable()) 
-				DynamicUpdateThread_.join();
-			else
-				break;
-			
-			std::this_thread::sleep_for(std::chrono::milliseconds(100));
-		}
+    {
+        std::lock_guard<std::mutex> Lock(DynamicInfoThreadMutex_);
+        ShouldDynamicInfoThreadRun_ = false;
+    }
+    DynamicInfoThreadCondition_.notify_all();
 
-		//If the thread is still running, terminate it
-		if (DynamicUpdateThread_.joinable()) {
-			DynamicUpdateThread_.detach();
-			
-		std::this_thread::sleep_for(std::chrono::milliseconds(100));
-			
-		if (DynamicUpdateThread_.joinable()) 
-			std::terminate();
-		}
-	}	
+    {
+        std::unique_lock<std::mutex> Lock(DynamicInfoThreadMutex_);
+        bool ThreadStopped = DynamicInfoThreadCondition_.wait_for(Lock, std::chrono::seconds(2), [this]() {
+            return !DynamicInfoThreadActive_;
+        });
+        if (!ThreadStopped) {
+            Logger_->Log("Dynamic hardware information thread did not stop within 2 seconds. ERS will keep waiting for a clean shutdown instead of forcing termination.", 9);
+        }
+    }
+
+    if (DynamicUpdateThread_.joinable()) {
+        DynamicUpdateThread_.join();
+    }
 }
 
 
@@ -155,15 +153,26 @@ void ERS_HardwareInformation::DynamicInformationThread() {
     // Name Thread
     SetThreadName("SysInfo");
 
-    while (ShouldDynamicInfoThreadRun_) {
+    while (true) {
 
         // Get Dynamic Info
         GetDynamicInformation();
 
-        // Wait For The WaitTime
-        std::this_thread::sleep_for(std::chrono::milliseconds((int)DynamicInfoRefreshRate_));
+        std::unique_lock<std::mutex> Lock(DynamicInfoThreadMutex_);
+        DynamicInfoThreadCondition_.wait_for(Lock, std::chrono::milliseconds((int)DynamicInfoRefreshRate_), [this]() {
+            return !ShouldDynamicInfoThreadRun_;
+        });
+        if (!ShouldDynamicInfoThreadRun_) {
+            break;
+        }
 
     }
+
+    {
+        std::lock_guard<std::mutex> Lock(DynamicInfoThreadMutex_);
+        DynamicInfoThreadActive_ = false;
+    }
+    DynamicInfoThreadCondition_.notify_all();
 
 }
 

--- a/Source/Internal/HardwareInformation/HardwareInformation.h
+++ b/Source/Internal/HardwareInformation/HardwareInformation.h
@@ -1,6 +1,8 @@
 #pragma once
 
 // Standard Libraries (BG convention: use <> instead of "")
+#include <condition_variable>
+#include <mutex>
 #include <thread>
 #include <chrono>
 
@@ -50,6 +52,9 @@ class ERS_HardwareInformation {
         // Control Vars
         float DynamicInfoRefreshRate_; /*<Set Number Of ms To wait until next dynamic info refresh*/
         bool ShouldDynamicInfoThreadRun_ = true; /**<Control Variable For Dynamic Info Thread*/
+        bool DynamicInfoThreadActive_ = false; /**<Tracks dynamic-info thread liveness during shutdown.*/
+        std::mutex DynamicInfoThreadMutex_; /**<Protects dynamic thread control state.*/
+        std::condition_variable DynamicInfoThreadCondition_; /**<Wakes the dynamic-info thread for shutdown and signals exit.*/
 
         std::thread DynamicUpdateThread_; /**<Dynamic Update Thread*/
 

--- a/Source/Internal/ModelImporter/ModelImporter.cpp
+++ b/Source/Internal/ModelImporter/ModelImporter.cpp
@@ -15,6 +15,7 @@ ERS_ModelImporter::ERS_ModelImporter(ERS_STRUCT_SystemUtils* SystemUtils) {
     ModelLoader_ = std::make_unique<BrainGenix::ERS::Module::ExternalModelLoader>(SystemUtils_);
 
     SystemUtils_->Logger_->Log("Starting Asset Import Thread", 4);
+    ImportThreadActive_ = true;
     ImportThread_ = std::thread(&ERS_ModelImporter::ImportThread, this);
     SystemUtils_->Logger_->Log("Started Asset Import Thread", 3);
 
@@ -32,37 +33,26 @@ ERS_ModelImporter::~ERS_ModelImporter() {
     SystemUtils_->Logger_->Log("Asset Importer Backend Destructor Called", 6);
 
     SystemUtils_->Logger_->Log("Sending Halt Signal To Asset Import Thread", 4);
-    BlockThread_.lock();
-    StopThread_ = true;
-    BlockThread_.unlock();
+    {
+        std::lock_guard<std::mutex> Lock(LockAssetImportQueue_);
+        StopThread_ = true;
+    }
+    WorkAvailableCondition_.notify_all();
+
+    {
+        std::unique_lock<std::mutex> Lock(LockAssetImportQueue_);
+        bool ImporterStopped = ImportThreadShutdownCondition_.wait_for(Lock, std::chrono::seconds(2), [this]() {
+            return !ImportThreadActive_;
+        });
+        if (!ImporterStopped) {
+            SystemUtils_->Logger_->Log("The asset import thread did not stop within 2 seconds. ERS will keep waiting for a clean shutdown instead of forcing termination.", 9);
+        }
+    }
 
     SystemUtils_->Logger_->Log("Joining Asset Import Thread", 3);
-	//if (ImportThread_.joinable()) {
-		//TerminateThread tt(std::thread(ImportThread_));
-	//}
-	
-	if (ImportThread_.joinable()) {
-		
-		// Wait for the thread to finish for up to 10 seconds
-		for (int i = 0; i < 100 && ImportThread_.joinable(); ++i) {
-			if (ImportThread_.joinable()) 
-				ImportThread_.join();
-			else
-				break;
-			
-			std::this_thread::sleep_for(std::chrono::milliseconds(100));
-		}
-
-		//If the thread is still running, terminate it
-		if (ImportThread_.joinable()) {
-			ImportThread_.detach();
-			
-		std::this_thread::sleep_for(std::chrono::milliseconds(100));
-			
-		if (ImportThread_.joinable()) 
-			std::terminate();
-		}
-	}	
+    if (ImportThread_.joinable()) {
+        ImportThread_.join();
+    }
 
 }
 
@@ -73,50 +63,50 @@ void ERS_ModelImporter::ImportThread() {
     SetThreadName("ImportManager");
 
     while (true) {
+        std::string AssetPath;
+        bool FlipTextures = false;
 
-        // Check Control Variables
-        BlockThread_.lock();
-        if (StopThread_) {
-            BlockThread_.unlock();
-            break;
-        }
-        BlockThread_.unlock();
+        {
+            std::unique_lock<std::mutex> Lock(LockAssetImportQueue_);
+            WorkAvailableCondition_.wait(Lock, [this]() {
+                return StopThread_ || !AssetImportQueue_.empty();
+            });
 
-        // Check Queue, Import As Needed, Empty Processing Items That Are Done
-        LockAssetImportQueue_.lock();
-        if (AssetImportQueue_.size() > 0) {
+            if (StopThread_) {
+                break;
+            }
 
             HasJobFinished_ = false;
-            std::string AssetPath = AssetImportQueue_[0];
-            bool FlipTextures = AssetQueueFlipTextures_[0];
+            AssetPath = AssetImportQueue_[0];
+            FlipTextures = AssetQueueFlipTextures_[0];
             AssetImportQueue_.erase(AssetImportQueue_.begin());
             AssetQueueFlipTextures_.erase(AssetQueueFlipTextures_.begin());
+        }
 
-            LockAssetImportQueue_.unlock();
+        ERS_STRUCT_Model Model;
+        ERS_STRUCT_ModelWriterData ModelData;
+        ModelData.Model = &Model;
+        ModelLoader_->LoadModel(AssetPath, ModelData);
+        ModelWriter_->WriteModel(ModelData, FlipTextures);
 
-
-                ERS_STRUCT_Model Model;
-                ERS_STRUCT_ModelWriterData ModelData;
-                ModelData.Model = &Model;
-                ModelLoader_->LoadModel(AssetPath, ModelData);
-                ModelWriter_->WriteModel(ModelData, FlipTextures);
-
-
-
-            LockAssetImportQueue_.lock();
+        {
+            std::lock_guard<std::mutex> Lock(LockAssetImportQueue_);
             TotalItemsProcessed_++;
-            LockAssetImportQueue_.unlock();
-        } else {
-            
-            HasJobFinished_ = true;
-            TotalItemsToImport_ = 0;
-            TotalItemsProcessed_ = 0;
-            LockAssetImportQueue_.unlock();
-
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            if (AssetImportQueue_.empty()) {
+                HasJobFinished_ = true;
+                TotalItemsToImport_ = 0;
+                TotalItemsProcessed_ = 0;
+            }
         }
 
     }
+
+    {
+        std::lock_guard<std::mutex> Lock(LockAssetImportQueue_);
+        HasJobFinished_ = true;
+        ImportThreadActive_ = false;
+    }
+    ImportThreadShutdownCondition_.notify_all();
 
 }
 
@@ -124,19 +114,20 @@ void ERS_ModelImporter::ImportThread() {
 void ERS_ModelImporter::AddToImportQueue(std::vector<std::string> AssetPaths, std::vector<bool> FlipTextures) {
 
     SystemUtils_->Logger_->Log("Appending Assets To Asset Import Queue", 5);
-    LockAssetImportQueue_.lock();
-    HasJobFinished_ = false;
-    for (int i = 0; (long)i < (long)AssetPaths.size(); i++) {
+    {
+        std::lock_guard<std::mutex> Lock(LockAssetImportQueue_);
+        HasJobFinished_ = false;
+        for (int i = 0; (long)i < (long)AssetPaths.size(); i++) {
 
-        std::string LogStr = std::string("Appending Asset: '") + AssetPaths[i] + std::string("' To Import Queue");
-        SystemUtils_->Logger_->Log(LogStr.c_str(), 4);
-        AssetImportQueue_.push_back(AssetPaths[i]);
-        AssetQueueFlipTextures_.push_back(FlipTextures[i]);
-        TotalItemsToImport_ += 1;
+            std::string LogStr = std::string("Appending Asset: '") + AssetPaths[i] + std::string("' To Import Queue");
+            SystemUtils_->Logger_->Log(LogStr.c_str(), 4);
+            AssetImportQueue_.push_back(AssetPaths[i]);
+            AssetQueueFlipTextures_.push_back(FlipTextures[i]);
+            TotalItemsToImport_ += 1;
 
+        }
     }
-
-    LockAssetImportQueue_.unlock();
+    WorkAvailableCondition_.notify_one();
 
 }
 long ERS_ModelImporter::GetTotalItemsToImport() {
@@ -146,8 +137,6 @@ long ERS_ModelImporter::GetTotalItemsImported() {
     return TotalItemsProcessed_;
 }
 bool ERS_ModelImporter::HasJobFinished() {
-    LockAssetImportQueue_.lock();
-    bool Out = HasJobFinished_;
-    LockAssetImportQueue_.unlock();
-    return Out;
+    std::lock_guard<std::mutex> Lock(LockAssetImportQueue_);
+    return HasJobFinished_;
 }

--- a/Source/Internal/ModelImporter/ModelImporter.h
+++ b/Source/Internal/ModelImporter/ModelImporter.h
@@ -9,6 +9,8 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <chrono>
+#include <condition_variable>
 #include <mutex>
 #include <future>
 #include <thread>
@@ -36,9 +38,11 @@ class ERS_ModelImporter {
 
         ERS_STRUCT_SystemUtils* SystemUtils_; /**<used to get access to system utilites like IOmanager, logger, etc.*/
         std::mutex LockAssetImportQueue_; /**<Mutex used to control access to list of assets to be imported*/
-        std::mutex BlockThread_; /**<Use This To Block The Thread*/
+        std::condition_variable WorkAvailableCondition_; /**<Wakes the import thread when new work arrives or shutdown begins.*/
+        std::condition_variable ImportThreadShutdownCondition_; /**<Signals that the import thread has fully exited.*/
         bool StopThread_ = false; /**<Set this to true to make the importer thread exit*/
         bool HasJobFinished_ = false; /**<Indicate If A Job Has Finished*/
+        bool ImportThreadActive_ = false; /**<Tracks import-thread liveness during shutdown.*/
         std::thread ImportThread_; /**<Import Processor Thread*/
         std::vector<std::string> AssetImportQueue_; /**<List of assets to be imported, accessed by other threads so use mutex to control access*/
         std::vector<bool> AssetQueueFlipTextures_; /**<List of assets flip texture parameter*/


### PR DESCRIPTION
Fixes #104.

This replaces the existing unsafe shutdown loops around the model-loading, asset-import, and dynamic hardware-information threads with a cooperative shutdown path.

Included in this patch:

- adds condition-variable wakeups so `ModelLoader` workers and `ModelImporter` do not rely on polling sleeps during shutdown
- adds the same cooperative stop/wake pattern to `ERS_HardwareInformation` so the dynamic system-info thread no longer relies on `detach()` / `terminate()` fallback
- removes the old `join`/`detach`/`terminate` destructor pattern and replaces it with a bounded delayed-shutdown warning followed by a normal join
- tracks worker-thread liveness so ERS can surface a warning when shutdown stalls instead of trying to forcefully terminate C++ worker threads
- moves `FreeImage_DeInitialise()` until after model-loader workers have finished, avoiding teardown while worker threads may still be using image-loading code

Verification:

- isolated the cooperative shutdown changes from unrelated GPU-selection and popup-warning work by rebuilding the patch from `origin/master`
- `git diff --no-index --check` passed for the isolated files
- full ERS build/runtime verification remains pending because the full ERS dependency stack is not installed in this environment

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.