### PR TITLE
Add EGL offscreen context selection

### DIFF
--- a/CMake/Scripts/EditorAssetsBundle/Config.yaml.in
+++ b/CMake/Scripts/EditorAssetsBundle/Config.yaml.in
@@ -3,6 +3,8 @@ WindowEnabled: True
 WindowWidth: 1920
 WindowHeight: 1080
 WindowTitle: "BrainGenix-ERS"
+OffscreenRendering: False
+OffscreenContextAPI: Native # Set to EGL to request an EGL OpenGL context when OffscreenRendering is true
 
 # System Settings
 ShowEditorDebugMenu: True

--- a/Source/Core/Renderer/ERS_CLASS_RendererManager/RendererManager.cpp
+++ b/Source/Core/Renderer/ERS_CLASS_RendererManager/RendererManager.cpp
@@ -160,6 +160,14 @@ void RendererManager::InitializeGLFW() {
     SystemUtils_->Logger_->Log("Read Configuration File For 'WindowTitle' Parameter", 1);
     WindowTitle_ = (*SystemUtils_->LocalSystemConfiguration_)["WindowTitle"].as<std::string>().c_str();
 
+    YAML::Node OffscreenRenderingNode = (*SystemUtils_->LocalSystemConfiguration_)["OffscreenRendering"];
+    OffscreenRendering_ = OffscreenRenderingNode ? OffscreenRenderingNode.as<bool>() : false;
+    if (OffscreenRendering_) {
+        SystemUtils_->Logger_->Log("Offscreen rendering enabled, creating the main GLFW context as a hidden window", 3);
+        glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+        glfwWindowHint(GLFW_FOCUS_ON_SHOW, GLFW_FALSE);
+    }
+
     // Create Window Object
     glfwSetErrorCallback(ErrorCallback);
     Window_ = glfwCreateWindow(WindowWidth_, WindowHeight_, WindowTitle_, NULL, NULL);
@@ -170,7 +178,12 @@ void RendererManager::InitializeGLFW() {
 
     // Bring Window To Front, Unlock Framerate So Our Framerate System Is Used
     glfwMakeContextCurrent(Window_);
-    glfwSwapInterval(1);
+    if (OffscreenRendering_) {
+        glfwSwapInterval(0);
+        SystemUtils_->Logger_->Log("Running renderer without presenting a visible GLFW window", 3);
+    } else {
+        glfwSwapInterval(1);
+    }
 
 
 

--- a/Source/Core/Renderer/ERS_CLASS_RendererManager/RendererManager.cpp
+++ b/Source/Core/Renderer/ERS_CLASS_RendererManager/RendererManager.cpp
@@ -4,6 +4,11 @@
 
 #include <RendererManager.h>
 
+// cppcheck-suppress missingIncludeSystem
+#include <algorithm>
+// cppcheck-suppress missingIncludeSystem
+#include <cctype>
+
 
 // FIXME! MAKE MORE CLEAN LOOKING OR SOMETHING
 void ErrorCallback(int, const char* ErrorString) {
@@ -158,19 +163,37 @@ void RendererManager::InitializeGLFW() {
     SystemUtils_->Logger_->Log("Read Configuration File For 'WindowHeight' Parameter", 1);
     WindowHeight_ = (*SystemUtils_->LocalSystemConfiguration_)["WindowHeight"].as<int>();
     SystemUtils_->Logger_->Log("Read Configuration File For 'WindowTitle' Parameter", 1);
-    WindowTitle_ = (*SystemUtils_->LocalSystemConfiguration_)["WindowTitle"].as<std::string>().c_str();
+    WindowTitle_ = (*SystemUtils_->LocalSystemConfiguration_)["WindowTitle"].as<std::string>();
 
     YAML::Node OffscreenRenderingNode = (*SystemUtils_->LocalSystemConfiguration_)["OffscreenRendering"];
     OffscreenRendering_ = OffscreenRenderingNode ? OffscreenRenderingNode.as<bool>() : false;
+
+    YAML::Node OffscreenContextAPINode = (*SystemUtils_->LocalSystemConfiguration_)["OffscreenContextAPI"];
+    std::string OffscreenContextAPI = OffscreenContextAPINode ? OffscreenContextAPINode.as<std::string>() : std::string("Native");
+    std::transform(OffscreenContextAPI.begin(), OffscreenContextAPI.end(), OffscreenContextAPI.begin(), [](unsigned char Character) {
+        return static_cast<char>(std::tolower(Character));
+    });
+    UseEGLContext_ = OffscreenRendering_ && (OffscreenContextAPI == "egl");
+
     if (OffscreenRendering_) {
         SystemUtils_->Logger_->Log("Offscreen rendering enabled, creating the main GLFW context as a hidden window", 3);
         glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
         glfwWindowHint(GLFW_FOCUS_ON_SHOW, GLFW_FALSE);
+
+        if (UseEGLContext_) {
+#ifdef GLFW_EGL_CONTEXT_API
+            glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
+            SystemUtils_->Logger_->Log("Requesting an EGL OpenGL context for off-screen rendering", 3);
+#else
+            UseEGLContext_ = false;
+            SystemUtils_->Logger_->Log("This GLFW build does not expose GLFW_EGL_CONTEXT_API; falling back to the native OpenGL context API", 7);
+#endif
+        }
     }
 
     // Create Window Object
     glfwSetErrorCallback(ErrorCallback);
-    Window_ = glfwCreateWindow(WindowWidth_, WindowHeight_, WindowTitle_, NULL, NULL);
+    Window_ = glfwCreateWindow(WindowWidth_, WindowHeight_, WindowTitle_.c_str(), NULL, NULL);
     if (Window_ == NULL) {
         glfwTerminate();
     }
@@ -180,7 +203,10 @@ void RendererManager::InitializeGLFW() {
     glfwMakeContextCurrent(Window_);
     if (OffscreenRendering_) {
         glfwSwapInterval(0);
-        SystemUtils_->Logger_->Log("Running renderer without presenting a visible GLFW window", 3);
+        std::string ContextMessage = UseEGLContext_
+            ? std::string("Running renderer without presenting a visible GLFW window using an EGL context")
+            : std::string("Running renderer without presenting a visible GLFW window using the native context API");
+        SystemUtils_->Logger_->Log(ContextMessage.c_str(), 3);
     } else {
         glfwSwapInterval(1);
     }

--- a/Source/Core/Renderer/ERS_CLASS_RendererManager/RendererManager.h
+++ b/Source/Core/Renderer/ERS_CLASS_RendererManager/RendererManager.h
@@ -65,8 +65,9 @@ private:
     // Control Values
     int         WindowWidth_  = 0;       /**<GLFW Window Width Varaible*/
     int         WindowHeight_ = 0;       /**<GLFW Window Height Varaible*/
-    const char* WindowTitle_  = nullptr; /**<GLFW Window Title Variable*/
+    std::string WindowTitle_;            /**<GLFW Window Title Variable*/
     bool        OffscreenRendering_ = false; /**<Run the main GLFW context as a hidden off-screen window.*/
+    bool        UseEGLContext_ = false; /**<Request an EGL OpenGL context for off-screen rendering.*/
 
 
     /**
@@ -121,6 +122,14 @@ public:
      * @return false
      */
     bool IsOffscreenRendering() const { return OffscreenRendering_; }
+
+    /**
+     * @brief Return whether the renderer requested an EGL context.
+     *
+     * @return true
+     * @return false
+     */
+    bool IsUsingEGLContext() const { return UseEGLContext_; }
 
     /**
      * @brief Called by the main loop, updates all rendered outputs.

--- a/Source/Core/Renderer/ERS_CLASS_RendererManager/RendererManager.h
+++ b/Source/Core/Renderer/ERS_CLASS_RendererManager/RendererManager.h
@@ -66,6 +66,7 @@ private:
     int         WindowWidth_  = 0;       /**<GLFW Window Width Varaible*/
     int         WindowHeight_ = 0;       /**<GLFW Window Height Varaible*/
     const char* WindowTitle_  = nullptr; /**<GLFW Window Title Variable*/
+    bool        OffscreenRendering_ = false; /**<Run the main GLFW context as a hidden off-screen window.*/
 
 
     /**
@@ -112,6 +113,14 @@ public:
      * 
      */
     ~RendererManager();
+
+    /**
+     * @brief Return whether the renderer is running without a visible window.
+     *
+     * @return true
+     * @return false
+     */
+    bool IsOffscreenRendering() const { return OffscreenRendering_; }
 
     /**
      * @brief Called by the main loop, updates all rendered outputs.


### PR DESCRIPTION
Fixes #468.

This upgrades the hidden offscreen startup path with a config-driven EGL context request for the renderer's main OpenGL context.

Included in this patch:

- adds `OffscreenRendering` and `OffscreenContextAPI` to the generated `Config.yaml`
- keeps the native context API as the default
- when `OffscreenRendering: True` and `OffscreenContextAPI: EGL`, requests `GLFW_EGL_CONTEXT_API`
- hides the main GLFW window, disables focus-on-show, and disables swap interval for offscreen mode
- logs whether the renderer is using EGL or the native context API, with a native fallback when GLFW does not expose `GLFW_EGL_CONTEXT_API`
- keeps the configured window title alive as a `std::string` instead of storing a `c_str()` pointer to a temporary
- rebases the branch on current upstream `master`, so the PR no longer drops later renderer changes

Out of scope for this issue:

- remote/server rendering orchestration and frame streaming, which belongs with #470
- GPU selection policy, which belongs with #469

Verification:

- `git diff --check origin/master`
- patch apply against a clean `origin/master` worktree with `git apply --check`
- `clang++ -std=c++17 -fsyntax-only Source/Core/Renderer/ERS_CLASS_RendererManager/RendererManager.cpp` with temporary stubs for unavailable external dependencies
- `cmake -S . -B Build/ers-468-check -G "Unix Makefiles"` still fails because this machine is missing `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` and a Unix Makefiles build program (`CMAKE_MAKE_PROGRAM` unset)

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.
