### PR TITLE
Add EGL-aware GPU selection exports

### DIFF
--- a/CMake/Scripts/EditorAssetsBundle/Config.yaml.in
+++ b/CMake/Scripts/EditorAssetsBundle/Config.yaml.in
@@ -9,6 +9,12 @@ ShowEditorDebugMenu: True
 EnableLogFile: True
 LogFilePathPrefix: Log  # Note that ERS will add the date/time and extension to this
 
+# GPU Selection Settings
+PreferDedicatedGPU: True
+PreferredGPUDeviceID: -1
+PreferredGPUVendor: ""
+PreferredGPUNameContains: ""
+
 # Database Loading Settings #
 UseDatabaseLoading: False
 DatabaseHost: "127.0.0.1" # FIX ME

--- a/Source/Core/Structures/ERS_STRUCT_HardwareInfo/HardwareInfo.h
+++ b/Source/Core/Structures/ERS_STRUCT_HardwareInfo/HardwareInfo.h
@@ -48,6 +48,11 @@ struct StaticHardwareInfo {
     std::vector<float> GPUVRAMSizes; /**<List of GPU VRAM Sizes*/
     std::vector<float> GPUCacheSize; /**<List OF GPU Cache Sizes*/
     std::vector<float> GPUMaxFreq; /**<:ist of GPU Max Frequency*/
+    int PreferredGPUDeviceID = -1; /**<Preferred GPU selected from config and hardware enumeration, or -1 if unset.*/
+    std::string PreferredGPUVendor; /**<Vendor of the preferred GPU selection.*/
+    std::string PreferredGPUName; /**<Name of the preferred GPU selection.*/
+    std::string PreferredGPUSelectionReason; /**<Why the preferred GPU was selected.*/
+    bool HasPreferredGPU = false; /**<Whether a preferred GPU was selected for future render backends.*/
 
 
 };

--- a/Source/Internal/GPURequest/GPURequest.cpp
+++ b/Source/Internal/GPURequest/GPURequest.cpp
@@ -4,3 +4,44 @@
 
 #include <GPURequest.h>
 
+#include <cstdlib>
+
+namespace {
+
+void SetGPUSelectionEnvVar(const char* Name, const std::string& Value) {
+#ifdef _WIN32
+    _putenv_s(Name, Value.c_str());
+#else
+    setenv(Name, Value.c_str(), 1);
+#endif
+}
+
+}
+
+void ERS_FUNCTION_ApplyGPUSelectionRequest(BG::Common::Logger::LoggingSystem* Logger, const ERS_STRUCT_HardwareInfo& HardwareInfo) {
+
+    if (!HardwareInfo.Static_.HasPreferredGPU) {
+        Logger->Log("No preferred GPU request was exported for future EGL/device-selection paths.", 3);
+        return;
+    }
+
+    SetGPUSelectionEnvVar("BG_ERS_PREFERRED_GPU_ID", std::to_string(HardwareInfo.Static_.PreferredGPUDeviceID));
+    SetGPUSelectionEnvVar("BG_ERS_PREFERRED_GPU_VENDOR", HardwareInfo.Static_.PreferredGPUVendor);
+    SetGPUSelectionEnvVar("BG_ERS_PREFERRED_GPU_NAME", HardwareInfo.Static_.PreferredGPUName);
+
+    Logger->Log(std::string("Exported preferred GPU request for future platform backends: Device ")
+        + std::to_string(HardwareInfo.Static_.PreferredGPUDeviceID)
+        + std::string(" [")
+        + HardwareInfo.Static_.PreferredGPUVendor
+        + std::string("] ")
+        + HardwareInfo.Static_.PreferredGPUName
+        + std::string(" (")
+        + HardwareInfo.Static_.PreferredGPUSelectionReason
+        + std::string(")"), 3);
+
+#ifdef _WIN32
+    Logger->Log("Windows discrete-GPU export symbols remain enabled; future EGL/non-Windows paths can also read BG_ERS_PREFERRED_GPU_*.", 3);
+#else
+    Logger->Log("Future EGL platform-device code can read BG_ERS_PREFERRED_GPU_* to bind the requested GPU explicitly.", 3);
+#endif
+}

--- a/Source/Internal/GPURequest/GPURequest.cpp
+++ b/Source/Internal/GPURequest/GPURequest.cpp
@@ -4,6 +4,7 @@
 
 #include <GPURequest.h>
 
+// cppcheck-suppress missingIncludeSystem
 #include <cstdlib>
 
 namespace {

--- a/Source/Internal/GPURequest/GPURequest.cpp
+++ b/Source/Internal/GPURequest/GPURequest.cpp
@@ -5,6 +5,10 @@
 #include <GPURequest.h>
 
 // cppcheck-suppress missingIncludeSystem
+#include <algorithm>
+// cppcheck-suppress missingIncludeSystem
+#include <cctype>
+// cppcheck-suppress missingIncludeSystem
 #include <cstdlib>
 
 namespace {
@@ -15,6 +19,18 @@ void SetGPUSelectionEnvVar(const char* Name, const std::string& Value) {
 #else
     setenv(Name, Value.c_str(), 1);
 #endif
+}
+
+bool ContainsInsensitive(const std::string& Value, const char* Needle) {
+    std::string ValueLower = Value;
+    std::string NeedleLower = Needle;
+    std::transform(ValueLower.begin(), ValueLower.end(), ValueLower.begin(), [](unsigned char Character) {
+        return static_cast<char>(std::tolower(Character));
+    });
+    std::transform(NeedleLower.begin(), NeedleLower.end(), NeedleLower.begin(), [](unsigned char Character) {
+        return static_cast<char>(std::tolower(Character));
+    });
+    return ValueLower.find(NeedleLower) != std::string::npos;
 }
 
 }
@@ -29,6 +45,7 @@ void ERS_FUNCTION_ApplyGPUSelectionRequest(BG::Common::Logger::LoggingSystem* Lo
     SetGPUSelectionEnvVar("BG_ERS_PREFERRED_GPU_ID", std::to_string(HardwareInfo.Static_.PreferredGPUDeviceID));
     SetGPUSelectionEnvVar("BG_ERS_PREFERRED_GPU_VENDOR", HardwareInfo.Static_.PreferredGPUVendor);
     SetGPUSelectionEnvVar("BG_ERS_PREFERRED_GPU_NAME", HardwareInfo.Static_.PreferredGPUName);
+    SetGPUSelectionEnvVar("BG_ERS_PREFERRED_GPU_REASON", HardwareInfo.Static_.PreferredGPUSelectionReason);
 
     Logger->Log(std::string("Exported preferred GPU request for future platform backends: Device ")
         + std::to_string(HardwareInfo.Static_.PreferredGPUDeviceID)
@@ -43,6 +60,18 @@ void ERS_FUNCTION_ApplyGPUSelectionRequest(BG::Common::Logger::LoggingSystem* Lo
 #ifdef _WIN32
     Logger->Log("Windows discrete-GPU export symbols remain enabled; future EGL/non-Windows paths can also read BG_ERS_PREFERRED_GPU_*.", 3);
 #else
-    Logger->Log("Future EGL platform-device code can read BG_ERS_PREFERRED_GPU_* to bind the requested GPU explicitly.", 3);
+    SetGPUSelectionEnvVar("DRI_PRIME", std::to_string(HardwareInfo.Static_.PreferredGPUDeviceID));
+    Logger->Log(std::string("Exported DRI_PRIME=")
+        + std::to_string(HardwareInfo.Static_.PreferredGPUDeviceID)
+        + std::string(" for Linux EGL/OpenGL GPU selection before renderer startup."), 3);
+
+    std::string PreferredGPUDescription = HardwareInfo.Static_.PreferredGPUVendor + std::string(" ") + HardwareInfo.Static_.PreferredGPUName;
+    if (ContainsInsensitive(PreferredGPUDescription, "nvidia")) {
+        SetGPUSelectionEnvVar("__NV_PRIME_RENDER_OFFLOAD", "1");
+        SetGPUSelectionEnvVar("__GLX_VENDOR_LIBRARY_NAME", "nvidia");
+        Logger->Log("Exported NVIDIA PRIME render-offload hints for the selected GPU.", 3);
+    }
+
+    Logger->Log("Future explicit EGL platform-device code can also read BG_ERS_PREFERRED_GPU_* to bind the requested GPU.", 3);
 #endif
 }

--- a/Source/Internal/GPURequest/GPURequest.h
+++ b/Source/Internal/GPURequest/GPURequest.h
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <HardwareInfo.h>
+#include <BG/Common/Logger/Logger.h>
+
 
 // Requests using the high power gpu on windows (YUCK!) platforms
 #ifdef _WIN32
@@ -18,3 +21,5 @@ __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
 }
 #endif
 #endif
+
+void ERS_FUNCTION_ApplyGPUSelectionRequest(BG::Common::Logger::LoggingSystem* Logger, const ERS_STRUCT_HardwareInfo& HardwareInfo);

--- a/Source/Internal/HardwareInformation/HardwareInformation.cpp
+++ b/Source/Internal/HardwareInformation/HardwareInformation.cpp
@@ -179,13 +179,17 @@ ERS_STRUCT_HardwareInfo ERS_HardwareInformation::GetHWInfo() {
 
 
 bool ERS_HardwareInformation::StringContainsInsensitive(const std::string& Haystack, const std::string& Needle) const {
+    if (Needle.empty()) {
+        return false;
+    }
+
     std::string HaystackLower = Haystack;
     std::string NeedleLower = Needle;
     std::transform(HaystackLower.begin(), HaystackLower.end(), HaystackLower.begin(), [](unsigned char Character) {
-        return (char)std::tolower(Character);
+        return static_cast<char>(std::tolower(Character));
     });
     std::transform(NeedleLower.begin(), NeedleLower.end(), NeedleLower.begin(), [](unsigned char Character) {
-        return (char)std::tolower(Character);
+        return static_cast<char>(std::tolower(Character));
     });
     return HaystackLower.find(NeedleLower) != std::string::npos;
 }
@@ -200,10 +204,12 @@ int ERS_HardwareInformation::SelectPreferredGPU(std::string& SelectionReason) co
     YAML::Node PreferredGPUDeviceIDNode = SystemConfiguration_["PreferredGPUDeviceID"];
     if (PreferredGPUDeviceIDNode) {
         int PreferredGPUDeviceID = PreferredGPUDeviceIDNode.as<int>();
-        for (unsigned int i = 0; i < HardwareInfo_.Static_.GPUDeviceIDs.size(); i++) {
-            if (HardwareInfo_.Static_.GPUDeviceIDs[i] == PreferredGPUDeviceID) {
-                SelectionReason = std::string("Matched PreferredGPUDeviceID=") + std::to_string(PreferredGPUDeviceID);
-                return (int)i;
+        if (PreferredGPUDeviceID >= 0) {
+            for (unsigned int i = 0; i < HardwareInfo_.Static_.GPUDeviceIDs.size(); i++) {
+                if (HardwareInfo_.Static_.GPUDeviceIDs[i] == PreferredGPUDeviceID) {
+                    SelectionReason = std::string("Matched PreferredGPUDeviceID=") + std::to_string(PreferredGPUDeviceID);
+                    return (int)i;
+                }
             }
         }
     }
@@ -211,10 +217,12 @@ int ERS_HardwareInformation::SelectPreferredGPU(std::string& SelectionReason) co
     YAML::Node PreferredGPUVendorNode = SystemConfiguration_["PreferredGPUVendor"];
     if (PreferredGPUVendorNode) {
         std::string PreferredGPUVendor = PreferredGPUVendorNode.as<std::string>();
-        for (unsigned int i = 0; i < HardwareInfo_.Static_.GPUVendors.size(); i++) {
-            if (StringContainsInsensitive(HardwareInfo_.Static_.GPUVendors[i], PreferredGPUVendor)) {
-                SelectionReason = std::string("Matched PreferredGPUVendor=") + PreferredGPUVendor;
-                return (int)i;
+        if (!PreferredGPUVendor.empty()) {
+            for (unsigned int i = 0; i < HardwareInfo_.Static_.GPUVendors.size(); i++) {
+                if (StringContainsInsensitive(HardwareInfo_.Static_.GPUVendors[i], PreferredGPUVendor)) {
+                    SelectionReason = std::string("Matched PreferredGPUVendor=") + PreferredGPUVendor;
+                    return (int)i;
+                }
             }
         }
     }
@@ -222,10 +230,12 @@ int ERS_HardwareInformation::SelectPreferredGPU(std::string& SelectionReason) co
     YAML::Node PreferredGPUNameNode = SystemConfiguration_["PreferredGPUNameContains"];
     if (PreferredGPUNameNode) {
         std::string PreferredGPUName = PreferredGPUNameNode.as<std::string>();
-        for (unsigned int i = 0; i < HardwareInfo_.Static_.GPUNames.size(); i++) {
-            if (StringContainsInsensitive(HardwareInfo_.Static_.GPUNames[i], PreferredGPUName)) {
-                SelectionReason = std::string("Matched PreferredGPUNameContains=") + PreferredGPUName;
-                return (int)i;
+        if (!PreferredGPUName.empty()) {
+            for (unsigned int i = 0; i < HardwareInfo_.Static_.GPUNames.size(); i++) {
+                if (StringContainsInsensitive(HardwareInfo_.Static_.GPUNames[i], PreferredGPUName)) {
+                    SelectionReason = std::string("Matched PreferredGPUNameContains=") + PreferredGPUName;
+                    return (int)i;
+                }
             }
         }
     }

--- a/Source/Internal/HardwareInformation/HardwareInformation.cpp
+++ b/Source/Internal/HardwareInformation/HardwareInformation.cpp
@@ -4,7 +4,9 @@
 
 #include <HardwareInformation.h>
 
+// cppcheck-suppress missingIncludeSystem
 #include <algorithm>
+// cppcheck-suppress missingIncludeSystem
 #include <cctype>
 
 

--- a/Source/Internal/HardwareInformation/HardwareInformation.cpp
+++ b/Source/Internal/HardwareInformation/HardwareInformation.cpp
@@ -4,6 +4,9 @@
 
 #include <HardwareInformation.h>
 
+#include <algorithm>
+#include <cctype>
+
 
 
 ERS_HardwareInformation::ERS_HardwareInformation(BG::Common::Logger::LoggingSystem* Logger, YAML::Node SystemConfig) {
@@ -82,6 +85,28 @@ ERS_HardwareInformation::ERS_HardwareInformation(BG::Common::Logger::LoggingSyst
 
 
         }
+        std::string PreferredGPUSelectionReason;
+        int PreferredGPUIndex = SelectPreferredGPU(PreferredGPUSelectionReason);
+        if ((PreferredGPUIndex >= 0) && ((unsigned int)PreferredGPUIndex < HardwareInfo_.Static_.GPUDeviceIDs.size())) {
+            HardwareInfo_.Static_.HasPreferredGPU = true;
+            HardwareInfo_.Static_.PreferredGPUDeviceID = HardwareInfo_.Static_.GPUDeviceIDs[PreferredGPUIndex];
+            HardwareInfo_.Static_.PreferredGPUVendor = HardwareInfo_.Static_.GPUVendors[PreferredGPUIndex];
+            HardwareInfo_.Static_.PreferredGPUName = HardwareInfo_.Static_.GPUNames[PreferredGPUIndex];
+            HardwareInfo_.Static_.PreferredGPUSelectionReason = PreferredGPUSelectionReason;
+
+            Logger_->Log(std::string("Preferred GPU Selection: Device ")
+                + std::to_string(HardwareInfo_.Static_.PreferredGPUDeviceID)
+                + std::string(" [")
+                + HardwareInfo_.Static_.PreferredGPUVendor
+                + std::string("] ")
+                + HardwareInfo_.Static_.PreferredGPUName
+                + std::string(" (")
+                + PreferredGPUSelectionReason
+                + std::string(")"), 3);
+        } else {
+            Logger_->Log("No preferred GPU was selected from the current configuration.", 3);
+        }
+
 
     } else {
 
@@ -148,6 +173,77 @@ std::thread ERS_HardwareInformation::SpawnThread() {
 
 ERS_STRUCT_HardwareInfo ERS_HardwareInformation::GetHWInfo() {
     return HardwareInfo_;
+}
+
+
+bool ERS_HardwareInformation::StringContainsInsensitive(const std::string& Haystack, const std::string& Needle) const {
+    std::string HaystackLower = Haystack;
+    std::string NeedleLower = Needle;
+    std::transform(HaystackLower.begin(), HaystackLower.end(), HaystackLower.begin(), [](unsigned char Character) {
+        return (char)std::tolower(Character);
+    });
+    std::transform(NeedleLower.begin(), NeedleLower.end(), NeedleLower.begin(), [](unsigned char Character) {
+        return (char)std::tolower(Character);
+    });
+    return HaystackLower.find(NeedleLower) != std::string::npos;
+}
+
+int ERS_HardwareInformation::SelectPreferredGPU(std::string& SelectionReason) const {
+
+    if (HardwareInfo_.Static_.GPUDeviceIDs.empty()) {
+        SelectionReason = "No detected GPU devices";
+        return -1;
+    }
+
+    YAML::Node PreferredGPUDeviceIDNode = SystemConfiguration_["PreferredGPUDeviceID"];
+    if (PreferredGPUDeviceIDNode) {
+        int PreferredGPUDeviceID = PreferredGPUDeviceIDNode.as<int>();
+        for (unsigned int i = 0; i < HardwareInfo_.Static_.GPUDeviceIDs.size(); i++) {
+            if (HardwareInfo_.Static_.GPUDeviceIDs[i] == PreferredGPUDeviceID) {
+                SelectionReason = std::string("Matched PreferredGPUDeviceID=") + std::to_string(PreferredGPUDeviceID);
+                return (int)i;
+            }
+        }
+    }
+
+    YAML::Node PreferredGPUVendorNode = SystemConfiguration_["PreferredGPUVendor"];
+    if (PreferredGPUVendorNode) {
+        std::string PreferredGPUVendor = PreferredGPUVendorNode.as<std::string>();
+        for (unsigned int i = 0; i < HardwareInfo_.Static_.GPUVendors.size(); i++) {
+            if (StringContainsInsensitive(HardwareInfo_.Static_.GPUVendors[i], PreferredGPUVendor)) {
+                SelectionReason = std::string("Matched PreferredGPUVendor=") + PreferredGPUVendor;
+                return (int)i;
+            }
+        }
+    }
+
+    YAML::Node PreferredGPUNameNode = SystemConfiguration_["PreferredGPUNameContains"];
+    if (PreferredGPUNameNode) {
+        std::string PreferredGPUName = PreferredGPUNameNode.as<std::string>();
+        for (unsigned int i = 0; i < HardwareInfo_.Static_.GPUNames.size(); i++) {
+            if (StringContainsInsensitive(HardwareInfo_.Static_.GPUNames[i], PreferredGPUName)) {
+                SelectionReason = std::string("Matched PreferredGPUNameContains=") + PreferredGPUName;
+                return (int)i;
+            }
+        }
+    }
+
+    YAML::Node PreferDedicatedGPUNode = SystemConfiguration_["PreferDedicatedGPU"];
+    bool PreferDedicatedGPU = PreferDedicatedGPUNode ? PreferDedicatedGPUNode.as<bool>() : false;
+    if (PreferDedicatedGPU) {
+        for (unsigned int i = 0; i < HardwareInfo_.Static_.GPUVendors.size(); i++) {
+            std::string Vendor = HardwareInfo_.Static_.GPUVendors[i];
+            if (!StringContainsInsensitive(Vendor, "Intel")
+                && !StringContainsInsensitive(Vendor, "Microsoft")
+                && !StringContainsInsensitive(Vendor, "Unknown")) {
+                SelectionReason = "PreferDedicatedGPU matched the first non-integrated vendor";
+                return (int)i;
+            }
+        }
+    }
+
+    SelectionReason = "Defaulted to the first detected GPU";
+    return 0;
 }
 
 void ERS_HardwareInformation::DynamicInformationThread() {

--- a/Source/Internal/HardwareInformation/HardwareInformation.h
+++ b/Source/Internal/HardwareInformation/HardwareInformation.h
@@ -3,6 +3,7 @@
 // Standard Libraries (BG convention: use <> instead of "")
 #include <thread>
 #include <chrono>
+#include <string>
 
 // Third-Party Libraries (BG convention: use <> instead of "")
 #include <yaml-cpp/yaml.h>
@@ -41,6 +42,8 @@ class ERS_HardwareInformation {
         const char* endianness_name(iware::cpu::endianness_t endianness) noexcept;
         const char* architecture_name(iware::cpu::architecture_t architecture) noexcept;
         const char* cache_type_name(iware::cpu::cache_type_t cache_type) noexcept;
+        bool StringContainsInsensitive(const std::string& Haystack, const std::string& Needle) const;
+        int SelectPreferredGPU(std::string& SelectionReason) const;
 
         // Internal Functions
         void GetDynamicInformation(); /**<Updates Dynamic Information*/

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -106,6 +106,7 @@ int main(int NumArguments, char** ArguemntValues) {
         SystemUtils->Logger_.get(),
         *SystemUtils->LocalSystemConfiguration_.get()
     );
+    ERS_FUNCTION_ApplyGPUSelectionRequest(SystemUtils->Logger_.get(), SystemUtils->ERS_HardwareInformation_->GetHWInfo());
 
    /* SystemUtils->ERS_CLASS_PythonInterpreterIntegration_ = std::make_unique<ERS_CLASS_PythonInterpreterIntegration>(
         SystemUtils->Logger_.get()


### PR DESCRIPTION
Fixes #469.

This adds a first-pass EGL-aware GPU selection path before renderer startup.

Included in this patch:

- extends hardware info with a preferred GPU device, vendor, name, and selection reason
- adds generated config defaults for `PreferDedicatedGPU`, `PreferredGPUDeviceID`, `PreferredGPUVendor`, and `PreferredGPUNameContains`
- selects the preferred GPU from explicit config hints, then `PreferDedicatedGPU`, then the first detected GPU
- ignores unset/default config values such as `PreferredGPUDeviceID: -1` and empty vendor/name filters
- exports `BG_ERS_PREFERRED_GPU_*` values for later explicit platform-device binding
- on non-Windows platforms, exports `DRI_PRIME=<device id>` before renderer startup so Mesa EGL/OpenGL device selection can pick the requested GPU
- exports NVIDIA PRIME render-offload hints when the selected GPU is NVIDIA
- keeps the existing Windows high-performance GPU exports in place

Notes:

- this does not add a full `EGL_EXT_platform_device` renderer backend; that would require a larger explicit EGL display/context path beyond the current GLFW startup flow
- paired with PR #504's `GLFW_EGL_CONTEXT_API` offscreen context path, this gives the EGL startup path a concrete GPU-selection request before GLFW creates the context

Verification:

- `git diff --check origin/master`
- patch apply against a clean `origin/master` worktree with `git apply --check`
- focused `GPURequest.cpp` executable check verifying `DRI_PRIME`, `BG_ERS_PREFERRED_GPU_*`, and NVIDIA PRIME hint exports
- focused `HardwareInformation.cpp` syntax check with temporary stubs for unavailable external dependencies
- `cmake -S . -B Build/ers-469-check -G "Unix Makefiles"` still fails because this machine is missing `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` and a Unix Makefiles build program (`CMAKE_MAKE_PROGRAM` unset)

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.
