### PR TITLE
Add first-pass scene distance sorter

### DIFF
--- a/Source/Core/Loader/ERS_ModelLoader/AssetStreamingManager.cpp
+++ b/Source/Core/Loader/ERS_ModelLoader/AssetStreamingManager.cpp
@@ -34,7 +34,7 @@ void ERS_CLASS_AssetStreamingManager::UpdateSceneStreamingQueue(ERS_STRUCT_Scene
     }
 
     // Sort All Models Based On Distance From Each Camera
-    std::vector<std::vector<std::pair<float, unsigned int>>> DistancesFromCamera = SortModelsByDistanceFromCameras(Scene, Cameras);
+    std::vector<std::vector<std::pair<float, unsigned int>>> DistancesFromCamera = ERS_CLASS_SceneSorter::SortModelsByDistanceFromCameras(Scene, Cameras);
 
     std::map<unsigned int, int> CameraUpdateQuota = CalculateCameraMaxUpdates(10, Cameras);
     SortSceneModels(CameraUpdateQuota, DistancesFromCamera, Scene);
@@ -46,12 +46,15 @@ void ERS_CLASS_AssetStreamingManager::SortSceneModels(std::map<unsigned int, int
     // Iterate Over All Cameras, Make Recomendations From There
     for (unsigned int CameraIndex = 0; CameraIndex < CameraUpdatesQuota.size(); CameraIndex++) {
 
-        
         // Sort Models From Cameras
+        if (CameraIndex >= DistancesFromCamera.size()) {
+            break;
+        }
+
         unsigned int MaxCameraUpdates = CameraUpdatesQuota[CameraIndex];
         unsigned int CameraVRAMUpdates = 0;
         unsigned int CameraRAMUpdates = 0;
-        for (auto DistanceMapIterator = DistancesFromCamera[0].begin(); DistanceMapIterator != DistancesFromCamera[0].end(); ++DistanceMapIterator) {
+        for (auto DistanceMapIterator = DistancesFromCamera[CameraIndex].begin(); DistanceMapIterator != DistancesFromCamera[CameraIndex].end(); ++DistanceMapIterator) {
             
             // Get Parameters From Model Array
             float ModelDistance = DistanceMapIterator->first;
@@ -351,48 +354,6 @@ std::map<unsigned int, int> ERS_CLASS_AssetStreamingManager::CalculateCameraMaxU
 
 }
 
-std::vector<std::vector<std::pair<float, unsigned int>>> ERS_CLASS_AssetStreamingManager::SortModelsByDistanceFromCameras(ERS_STRUCT_Scene* Scene, std::vector<ERS_STRUCT_Camera*> Cameras) {
-
-    std::vector<std::vector<std::pair<float, unsigned int>>> DistancesFromCamera;
-    for (unsigned int i = 0; i < Cameras.size(); i++) {
-        DistancesFromCamera.push_back(SortModelsByDistanceFromCamera(Scene, Cameras[i]));
-    }
-    return DistancesFromCamera;
-
-}
-
-std::vector<std::pair<float, unsigned int>> ERS_CLASS_AssetStreamingManager::SortModelsByDistanceFromCamera(ERS_STRUCT_Scene* Scene, ERS_STRUCT_Camera* Camera) {
-
-    // Create Sorted List Of Distances Based On Position
-    std::vector<std::pair<float, unsigned int>> Distances;        
-    for (unsigned int i = 0; i < Scene->Models.size(); i++) {
-
-
-        float TotalDistance = glm::distance(Camera->GetPosition(), Scene->Models[i]->ModelPosition);
-  
-        glm::vec3 CubeBoundryBox = Scene->Models[i]->BoxScale_ * Scene->Models[i]->TrueModelScale;
-        float ApproxCubeBoundryDistance = CubeBoundryBox.x;
-        if (ApproxCubeBoundryDistance < CubeBoundryBox.y) {
-            ApproxCubeBoundryDistance = CubeBoundryBox.y;
-        } else if (ApproxCubeBoundryDistance < CubeBoundryBox.z) {
-            ApproxCubeBoundryDistance = CubeBoundryBox.z;
-        }
-        float Distance = TotalDistance - ApproxCubeBoundryDistance;
-
-        // Cap Distance At 0 - We don't want negative distance, (thats happens if the camera is inside the bounding box of the model)
-        Distance = std::max(0.0f, Distance);
-        Distances.push_back(std::make_pair(Distance, i));
-    }
-
-
-    std::vector<std::pair<float, unsigned int>> SortedDistances; 
-    for (std::pair<float, unsigned int> Entry : Distances) {
-        SortedDistances.push_back(std::make_pair(Entry.first, Entry.second));
-    }
-
-    return SortedDistances;
-}
-
 void ERS_CLASS_AssetStreamingManager::WorkerThread() {
     SystemUtils_->Logger_->Log("Asset Streaming Subsystem Sorting Thread Started", 3);
     while (true) {
@@ -421,6 +382,4 @@ void ERS_CLASS_AssetStreamingManager::SetCurrentScene(ERS_STRUCT_Scene* Scene) {
 void ERS_CLASS_AssetStreamingManager::SetCameraStructs(std::vector<ERS_STRUCT_Camera*> Cameras) {
     Cameras_ = Cameras;
 }
-
-
 

--- a/Source/Core/Loader/ERS_ModelLoader/AssetStreamingManager.h
+++ b/Source/Core/Loader/ERS_ModelLoader/AssetStreamingManager.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <thread>
 #include <chrono>
+#include <map>
 #include <mutex>
 #include <memory>
 
@@ -17,6 +18,7 @@
 // Internal Libraries (BG convention: use <> instead of "")
 #include <SystemUtils.h>
 #include <Scene.h>
+#include <SceneSorter.h>
 #include <Camera.h>
 
 
@@ -86,26 +88,6 @@ private:
      * 
      */
     void CheckHardwareLimitations(ERS_STRUCT_Scene* Scene);
-
-    /**
-     * @brief Sorts the models in the given scene based on their distance from the camera.
-     * Returns a map containing the distance as well as the index in the model list for that model.
-     * 
-     * @param Scene 
-     * @param Camera 
-     * @return std::map<float, unsigned int> 
-     */
-    std::vector<std::pair<float, unsigned int>> SortModelsByDistanceFromCamera(ERS_STRUCT_Scene* Scene, ERS_STRUCT_Camera* Camera);
-
-    /**
-     * @brief Sorts all models in the scene for every camera.
-     * Returns map of distances and model index sorted by distance for each camera.
-     * 
-     * @param Scene 
-     * @param Cameras 
-     * @return std::vector<std::map<float, unsigned int>> 
-     */
-    std::vector<std::vector<std::pair<float, unsigned int>>> SortModelsByDistanceFromCameras(ERS_STRUCT_Scene* Scene, std::vector<ERS_STRUCT_Camera*> Cameras);
 
     /**
      * @brief Generates a dictionary based on the camera's pointer indicating how many loads/unloads should be allowed for every camera

--- a/Source/Core/Structures/ERS_STRUCT_Scene/CMakeLists.txt
+++ b/Source/Core/Structures/ERS_STRUCT_Scene/CMakeLists.txt
@@ -8,9 +8,11 @@ add_library(ERS_STRUCT_Scene
 
             # Add Source Files (.cpp)
             "Scene.cpp"
+            "SceneSorter.cpp"
 
             # Add Header Files (.h)
             "Scene.h"
+            "SceneSorter.h"
             
             ${BACKWARD_ENABLE}
             )
@@ -26,6 +28,7 @@ target_link_libraries(ERS_STRUCT_Scene
     ERS_STRUCT_Light
     ERS_STRUCT_SceneObject
     ERS_STRUCT_SceneCamera
+    ERS_STRUCT_Camera
     )
 
 target_include_directories(ERS_STRUCT_Scene PUBLIC ./)

--- a/Source/Core/Structures/ERS_STRUCT_Scene/SceneSorter.cpp
+++ b/Source/Core/Structures/ERS_STRUCT_Scene/SceneSorter.cpp
@@ -1,0 +1,78 @@
+//======================================================================//
+// This file is part of the BrainGenix-ERS Environment Rendering System //
+//======================================================================//
+
+#include <SceneSorter.h>
+
+// Standard Libraries (BG convention: use <> instead of "")
+#include <algorithm>
+#include <future>
+
+// Third-Party Libraries (BG convention: use <> instead of "")
+#include <glm/geometric.hpp>
+
+
+std::vector<std::pair<float, unsigned int>> ERS_CLASS_SceneSorter::SortModelsByDistanceFromCamera(ERS_STRUCT_Scene* Scene, ERS_STRUCT_Camera* Camera) {
+
+    std::vector<std::pair<float, unsigned int>> Distances;
+    if (Scene == nullptr || Camera == nullptr) {
+        return Distances;
+    }
+
+    Distances.reserve(Scene->Models.size());
+    glm::vec3 CameraPosition = Camera->GetPosition();
+
+    for (unsigned int i = 0; i < Scene->Models.size(); i++) {
+        if (Scene->Models[i] == nullptr) {
+            continue;
+        }
+
+        float TotalDistance = glm::distance(CameraPosition, Scene->Models[i]->ModelPosition);
+
+        glm::vec3 CubeBoundaryBox = Scene->Models[i]->BoxScale_ * Scene->Models[i]->TrueModelScale;
+        float ApproxCubeBoundaryDistance = std::max(CubeBoundaryBox.x, std::max(CubeBoundaryBox.y, CubeBoundaryBox.z));
+        float Distance = TotalDistance - ApproxCubeBoundaryDistance;
+
+        // Cap distance at 0 when the camera is inside the model bounds.
+        Distance = std::max(0.0f, Distance);
+        Distances.push_back(std::make_pair(Distance, i));
+    }
+
+    std::stable_sort(
+        Distances.begin(),
+        Distances.end(),
+        [](const std::pair<float, unsigned int>& Left, const std::pair<float, unsigned int>& Right) {
+            if (Left.first == Right.first) {
+                return Left.second < Right.second;
+            }
+            return Left.first < Right.first;
+        }
+    );
+
+    return Distances;
+}
+
+std::vector<std::vector<std::pair<float, unsigned int>>> ERS_CLASS_SceneSorter::SortModelsByDistanceFromCameras(ERS_STRUCT_Scene* Scene, std::vector<ERS_STRUCT_Camera*> Cameras) {
+
+    std::vector<std::vector<std::pair<float, unsigned int>>> DistancesFromCamera(Cameras.size());
+    if (Scene == nullptr || Cameras.size() == 0) {
+        return DistancesFromCamera;
+    }
+
+    if (Cameras.size() == 1) {
+        DistancesFromCamera[0] = SortModelsByDistanceFromCamera(Scene, Cameras[0]);
+        return DistancesFromCamera;
+    }
+
+    std::vector<std::future<std::vector<std::pair<float, unsigned int>>>> SortTasks;
+    SortTasks.reserve(Cameras.size());
+    for (unsigned int i = 0; i < Cameras.size(); i++) {
+        SortTasks.push_back(std::async(std::launch::async, ERS_CLASS_SceneSorter::SortModelsByDistanceFromCamera, Scene, Cameras[i]));
+    }
+
+    for (unsigned int i = 0; i < SortTasks.size(); i++) {
+        DistancesFromCamera[i] = SortTasks[i].get();
+    }
+
+    return DistancesFromCamera;
+}

--- a/Source/Core/Structures/ERS_STRUCT_Scene/SceneSorter.cpp
+++ b/Source/Core/Structures/ERS_STRUCT_Scene/SceneSorter.cpp
@@ -2,13 +2,17 @@
 // This file is part of the BrainGenix-ERS Environment Rendering System //
 //======================================================================//
 
+// cppcheck-suppress missingIncludeSystem
 #include <SceneSorter.h>
 
 // Standard Libraries (BG convention: use <> instead of "")
+// cppcheck-suppress missingIncludeSystem
 #include <algorithm>
+// cppcheck-suppress missingIncludeSystem
 #include <future>
 
 // Third-Party Libraries (BG convention: use <> instead of "")
+// cppcheck-suppress missingIncludeSystem
 #include <glm/geometric.hpp>
 
 

--- a/Source/Core/Structures/ERS_STRUCT_Scene/SceneSorter.h
+++ b/Source/Core/Structures/ERS_STRUCT_Scene/SceneSorter.h
@@ -1,0 +1,44 @@
+//======================================================================//
+// This file is part of the BrainGenix-ERS Environment Rendering System //
+//======================================================================//
+
+#pragma once
+
+// Standard Libraries (BG convention: use <> instead of "")
+#include <utility>
+#include <vector>
+
+// Third-Party Libraries (BG convention: use <> instead of "")
+
+// Internal Libraries (BG convention: use <> instead of "")
+#include <Camera.h>
+#include <Scene.h>
+
+
+/**
+ * @brief Utility class for read-only scene sorting operations.
+ *
+ */
+class ERS_CLASS_SceneSorter {
+
+public:
+
+    /**
+     * @brief Sort models in a scene by distance from a camera.
+     *
+     * @param Scene Scene to inspect.
+     * @param Camera Camera to sort from.
+     * @return std::vector<std::pair<float, unsigned int>> Distance plus model index, sorted nearest first.
+     */
+    static std::vector<std::pair<float, unsigned int>> SortModelsByDistanceFromCamera(ERS_STRUCT_Scene* Scene, ERS_STRUCT_Camera* Camera);
+
+    /**
+     * @brief Sort models in a scene by distance from multiple cameras.
+     *
+     * @param Scene Scene to inspect.
+     * @param Cameras Cameras to sort from.
+     * @return std::vector<std::vector<std::pair<float, unsigned int>>> Per-camera sorted model distances.
+     */
+    static std::vector<std::vector<std::pair<float, unsigned int>>> SortModelsByDistanceFromCameras(ERS_STRUCT_Scene* Scene, std::vector<ERS_STRUCT_Camera*> Cameras);
+
+};


### PR DESCRIPTION
Fixes #312.

## Summary
- add `ERS_CLASS_SceneSorter` for read-only model distance sorting from one or more cameras
- use `std::async` to sort per-camera distance lists in parallel when more than one camera is present
- delegate asset streaming distance sorting to the new helper and use each camera's own sorted list when applying streaming recommendations

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `git diff --check`
- `gh pr diff 508 --repo carboncopies/BrainGenix-ERS --patch | git apply --check --whitespace=error-all -` against a fresh `origin/master` export
- `clang++ -std=c++17 -fsyntax-only Source/Core/Structures/ERS_STRUCT_Scene/SceneSorter.cpp ...` (blocked by missing local third-party/project headers: `yaml-cpp/yaml.h`, then `BG/Common/Logger/Logger.h`)
- `cd Tools && bash Build.sh 4 Debug` (configuration fails locally because the vcpkg toolchain file is missing and CMake has no Make generator configured in this checkout)