### PR TITLE
Add first-pass transform undo

### DIFF
--- a/Source/Core/Manager/ERS_SceneManager/SceneManager.cpp
+++ b/Source/Core/Manager/ERS_SceneManager/SceneManager.cpp
@@ -21,36 +21,160 @@ ERS_CLASS_SceneManager::~ERS_CLASS_SceneManager() {
 
 void ERS_CLASS_SceneManager::UpdateLocRotScale(glm::vec3 Pos, glm::vec3 Rot, glm::vec3 Scale) {
 
+    if (Scenes_.empty() || ActiveScene_ < 0 || (unsigned long)ActiveScene_ >= Scenes_.size()) {
+        Logger_->Log("Cannot update LocRotScale because the active scene is invalid", 7);
+        return;
+    }
+
     if (Scenes_[ActiveScene_]->SceneObjects_.empty()) {
         Logger_->Log("Scene has no models");
-        return; 
+        return;
     }
 
-    unsigned long SelectedObject = Scenes_[ActiveScene_]->SelectedObject;
+    ApplyLocRotScale(ActiveScene_, Scenes_[ActiveScene_]->SelectedObject, Pos, Rot, Scale);
+}
 
-    if (SelectedObject >= Scenes_[ActiveScene_]->SceneObjects_.size()) {
+bool ERS_CLASS_SceneManager::GetSelectedLocRotScale(glm::vec3& Pos, glm::vec3& Rot, glm::vec3& Scale, bool& HasRotation, bool& HasScale) {
+
+    if (Scenes_.empty() || ActiveScene_ < 0 || (unsigned long)ActiveScene_ >= Scenes_.size()) {
+        return false;
+    }
+
+    return GetLocRotScale(ActiveScene_, Scenes_[ActiveScene_]->SelectedObject, Pos, Rot, Scale, HasRotation, HasScale);
+}
+
+bool ERS_CLASS_SceneManager::GetLocRotScale(int SceneIndex, unsigned long SceneObjectIndex, glm::vec3& Pos, glm::vec3& Rot, glm::vec3& Scale, bool& HasRotation, bool& HasScale) {
+
+    Pos = glm::vec3(0.0f);
+    Rot = glm::vec3(0.0f);
+    Scale = glm::vec3(1.0f);
+    HasRotation = false;
+    HasScale = false;
+
+    if (SceneIndex < 0 || (unsigned long)SceneIndex >= Scenes_.size()) {
+        Logger_->Log("Cannot read LocRotScale from invalid scene index", 7);
+        return false;
+    }
+
+    ERS_STRUCT_Scene* Scene = Scenes_[SceneIndex].get();
+    if (Scene->SceneObjects_.empty()) {
+        Logger_->Log("Scene has no models");
+        return false;
+    }
+
+    if (SceneObjectIndex >= Scene->SceneObjects_.size()) {
         Logger_->Log("Selected Scene Object is out of bounds.");
-        return; 
+        return false;
     }
 
-    auto& selectedObject = Scenes_[ActiveScene_]->SceneObjects_[SelectedObject];
+    auto& SelectedObject = Scene->SceneObjects_[SceneObjectIndex];
 
-    if (selectedObject.Type_ == "Model") {
-        unsigned long Index = selectedObject.Index_;
-        Scenes_[ActiveScene_]->Models[Index]->SetLocRotScale(Pos, Rot, Scale);
-        Scenes_[ActiveScene_]->Models[Index]->ApplyTransformations();
-    } else if (selectedObject.Type_ == "PointLight") {
-        unsigned long Index = selectedObject.Index_;
-        Scenes_[ActiveScene_]->PointLights[Index]->Pos = Pos;
-    } else if (selectedObject.Type_ == "DirectionalLight" || selectedObject.Type_ == "SpotLight") {
-        unsigned long Index = selectedObject.Index_;
-        Scenes_[ActiveScene_]->DirectionalLights[Index]->Pos = Pos;
-        Scenes_[ActiveScene_]->DirectionalLights[Index]->Rot = Rot;
-    } else if (selectedObject.Type_ == "SceneCamera") {
-        unsigned long Index = selectedObject.Index_;
-        Scenes_[ActiveScene_]->SceneCameras[Index]->Pos_ = Pos;
-        Scenes_[ActiveScene_]->SceneCameras[Index]->Rot_ = Rot;
+    if (SelectedObject.Type_ == "Model") {
+        unsigned long Index = SelectedObject.Index_;
+        if (Index >= Scene->Models.size()) {
+            return false;
+        }
+        Pos = Scene->Models[Index]->ModelPosition;
+        Rot = Scene->Models[Index]->ModelRotation;
+        Scale = Scene->Models[Index]->ModelScale;
+        HasRotation = true;
+        HasScale = true;
+    } else if (SelectedObject.Type_ == "PointLight") {
+        unsigned long Index = SelectedObject.Index_;
+        if (Index >= Scene->PointLights.size()) {
+            return false;
+        }
+        Pos = Scene->PointLights[Index]->Pos;
+    } else if (SelectedObject.Type_ == "DirectionalLight") {
+        unsigned long Index = SelectedObject.Index_;
+        if (Index >= Scene->DirectionalLights.size()) {
+            return false;
+        }
+        Pos = Scene->DirectionalLights[Index]->Pos;
+        Rot = Scene->DirectionalLights[Index]->Rot;
+        HasRotation = true;
+    } else if (SelectedObject.Type_ == "SpotLight") {
+        unsigned long Index = SelectedObject.Index_;
+        if (Index >= Scene->SpotLights.size()) {
+            return false;
+        }
+        Pos = Scene->SpotLights[Index]->Pos;
+        Rot = Scene->SpotLights[Index]->Rot;
+        HasRotation = true;
+    } else if (SelectedObject.Type_ == "SceneCamera") {
+        unsigned long Index = SelectedObject.Index_;
+        if (Index >= Scene->SceneCameras.size()) {
+            return false;
+        }
+        Pos = Scene->SceneCameras[Index]->Pos_;
+        Rot = Scene->SceneCameras[Index]->Rot_;
+        HasRotation = true;
+    } else {
+        return false;
     }
+
+    return true;
+}
+
+bool ERS_CLASS_SceneManager::ApplyLocRotScale(int SceneIndex, unsigned long SceneObjectIndex, glm::vec3 Pos, glm::vec3 Rot, glm::vec3 Scale) {
+
+    if (SceneIndex < 0 || (unsigned long)SceneIndex >= Scenes_.size()) {
+        Logger_->Log("Cannot update LocRotScale on invalid scene index", 7);
+        return false;
+    }
+
+    ERS_STRUCT_Scene* Scene = Scenes_[SceneIndex].get();
+    if (Scene->SceneObjects_.empty()) {
+        Logger_->Log("Scene has no models");
+        return false;
+    }
+
+    if (SceneObjectIndex >= Scene->SceneObjects_.size()) {
+        Logger_->Log("Selected Scene Object is out of bounds.");
+        return false;
+    }
+
+    auto& SelectedObject = Scene->SceneObjects_[SceneObjectIndex];
+
+    if (SelectedObject.Type_ == "Model") {
+        unsigned long Index = SelectedObject.Index_;
+        if (Index >= Scene->Models.size()) {
+            return false;
+        }
+        Scene->Models[Index]->SetLocRotScale(Pos, Rot, Scale);
+        Scene->Models[Index]->ApplyTransformations();
+    } else if (SelectedObject.Type_ == "PointLight") {
+        unsigned long Index = SelectedObject.Index_;
+        if (Index >= Scene->PointLights.size()) {
+            return false;
+        }
+        Scene->PointLights[Index]->Pos = Pos;
+    } else if (SelectedObject.Type_ == "DirectionalLight") {
+        unsigned long Index = SelectedObject.Index_;
+        if (Index >= Scene->DirectionalLights.size()) {
+            return false;
+        }
+        Scene->DirectionalLights[Index]->Pos = Pos;
+        Scene->DirectionalLights[Index]->Rot = Rot;
+    } else if (SelectedObject.Type_ == "SpotLight") {
+        unsigned long Index = SelectedObject.Index_;
+        if (Index >= Scene->SpotLights.size()) {
+            return false;
+        }
+        Scene->SpotLights[Index]->Pos = Pos;
+        Scene->SpotLights[Index]->Rot = Rot;
+    } else if (SelectedObject.Type_ == "SceneCamera") {
+        unsigned long Index = SelectedObject.Index_;
+        if (Index >= Scene->SceneCameras.size()) {
+            return false;
+        }
+        Scene->SceneCameras[Index]->Pos_ = Pos;
+        Scene->SceneCameras[Index]->Rot_ = Rot;
+    } else {
+        return false;
+    }
+
+    return true;
 }
 
 

--- a/Source/Core/Manager/ERS_SceneManager/SceneManager.h
+++ b/Source/Core/Manager/ERS_SceneManager/SceneManager.h
@@ -85,6 +85,47 @@ public:
      * @param LocRotScale 
      */
     void UpdateLocRotScale(glm::vec3 Pos, glm::vec3 Rot, glm::vec3 Scale);
+
+    /**
+     * @brief Get LocRotScale for a scene object.
+     *
+     * @param SceneIndex
+     * @param SceneObjectIndex
+     * @param Pos
+     * @param Rot
+     * @param Scale
+     * @param HasRotation
+     * @param HasScale
+     * @return true
+     * @return false
+     */
+    bool GetLocRotScale(int SceneIndex, unsigned long SceneObjectIndex, glm::vec3& Pos, glm::vec3& Rot, glm::vec3& Scale, bool& HasRotation, bool& HasScale);
+
+    /**
+     * @brief Get LocRotScale for the selected object in the active scene.
+     *
+     * @param Pos
+     * @param Rot
+     * @param Scale
+     * @param HasRotation
+     * @param HasScale
+     * @return true
+     * @return false
+     */
+    bool GetSelectedLocRotScale(glm::vec3& Pos, glm::vec3& Rot, glm::vec3& Scale, bool& HasRotation, bool& HasScale);
+
+    /**
+     * @brief Apply LocRotScale to a scene object.
+     *
+     * @param SceneIndex
+     * @param SceneObjectIndex
+     * @param Pos
+     * @param Rot
+     * @param Scale
+     * @return true
+     * @return false
+     */
+    bool ApplyLocRotScale(int SceneIndex, unsigned long SceneObjectIndex, glm::vec3 Pos, glm::vec3 Rot, glm::vec3 Scale);
     
 
 

--- a/Source/Core/Renderer/ERS_CLASS_VisualRenderer/VisualRenderer.cpp
+++ b/Source/Core/Renderer/ERS_CLASS_VisualRenderer/VisualRenderer.cpp
@@ -56,6 +56,105 @@ void ERS_CLASS_VisualRenderer::SetOpenGLDefaults(ERS_STRUCT_OpenGLDefaults* Defa
 
 }
 
+static bool ERS_FUNCTION_TransformUndoValuesDiffer(glm::vec3 Left, glm::vec3 Right) {
+    return glm::length(Left - Right) > 0.0001f;
+}
+
+void ERS_CLASS_VisualRenderer::BeginTransformUndoRecord(ERS_CLASS_SceneManager* SceneManager) {
+
+    if (TransformUndoRecordActive_ || SceneManager->Scenes_.empty()
+        || SceneManager->ActiveScene_ < 0
+        || (unsigned long)SceneManager->ActiveScene_ >= SceneManager->Scenes_.size()) {
+        return;
+    }
+
+    ERS_STRUCT_TransformUndoRecord Record;
+    Record.SceneIndex = SceneManager->ActiveScene_;
+    Record.SceneObjectIndex = SceneManager->Scenes_[SceneManager->ActiveScene_]->SelectedObject;
+
+    if (!SceneManager->GetSelectedLocRotScale(Record.BeforePos, Record.BeforeRot, Record.BeforeScale, Record.HasRotation, Record.HasScale)) {
+        return;
+    }
+
+    ActiveTransformUndoRecord_ = Record;
+    TransformUndoRecordActive_ = true;
+}
+
+void ERS_CLASS_VisualRenderer::FinishTransformUndoRecord(ERS_CLASS_SceneManager* SceneManager) {
+
+    if (!TransformUndoRecordActive_) {
+        return;
+    }
+
+    ERS_STRUCT_TransformUndoRecord Record = ActiveTransformUndoRecord_;
+    bool HasRotation = false;
+    bool HasScale = false;
+    if (!SceneManager->GetLocRotScale(Record.SceneIndex, Record.SceneObjectIndex, Record.AfterPos, Record.AfterRot, Record.AfterScale, HasRotation, HasScale)) {
+        TransformUndoRecordActive_ = false;
+        return;
+    }
+
+    bool HasChanged = ERS_FUNCTION_TransformUndoValuesDiffer(Record.BeforePos, Record.AfterPos)
+        || ERS_FUNCTION_TransformUndoValuesDiffer(Record.BeforeRot, Record.AfterRot)
+        || ERS_FUNCTION_TransformUndoValuesDiffer(Record.BeforeScale, Record.AfterScale);
+
+    if (HasChanged) {
+        TransformUndoStack_.push_back(Record);
+        TransformRedoStack_.clear();
+    }
+
+    TransformUndoRecordActive_ = false;
+}
+
+bool ERS_CLASS_VisualRenderer::ApplyTransformUndoRecord(ERS_CLASS_SceneManager* SceneManager, const ERS_STRUCT_TransformUndoRecord& Record, bool ApplyAfter) {
+
+    glm::vec3 Pos = ApplyAfter ? Record.AfterPos : Record.BeforePos;
+    glm::vec3 Rot = ApplyAfter ? Record.AfterRot : Record.BeforeRot;
+    glm::vec3 Scale = ApplyAfter ? Record.AfterScale : Record.BeforeScale;
+
+    if (!SceneManager->ApplyLocRotScale(Record.SceneIndex, Record.SceneObjectIndex, Pos, Rot, Scale)) {
+        return false;
+    }
+
+    SceneManager->SetActiveScene(Record.SceneIndex);
+    SceneManager->Scenes_[Record.SceneIndex]->SelectedObject = Record.SceneObjectIndex;
+    SceneManager->Scenes_[Record.SceneIndex]->HasSelectionChanged = true;
+    Cursors3D_->SetLocRotScale(Pos, Rot, Scale, Record.HasRotation, Record.HasScale);
+    Cursors3D_->ObjectHasChanged();
+
+    return true;
+}
+
+void ERS_CLASS_VisualRenderer::HandleTransformUndoShortcuts(ERS_CLASS_SceneManager* SceneManager) {
+
+    if (!IsEditorMode_ || TransformUndoRecordActive_) {
+        return;
+    }
+
+    ImGuiIO& IO = ImGui::GetIO();
+    if (IO.WantTextInput || !(IO.KeyCtrl || IO.KeySuper)) {
+        return;
+    }
+
+    bool UndoPressed = ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_Z), false) && !IO.KeyShift;
+    bool RedoPressed = ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_Y), false)
+        || (ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_Z), false) && IO.KeyShift);
+
+    if (RedoPressed && !TransformRedoStack_.empty()) {
+        ERS_STRUCT_TransformUndoRecord Record = TransformRedoStack_.back();
+        TransformRedoStack_.pop_back();
+        if (ApplyTransformUndoRecord(SceneManager, Record, true)) {
+            TransformUndoStack_.push_back(Record);
+        }
+    } else if (UndoPressed && !TransformUndoStack_.empty()) {
+        ERS_STRUCT_TransformUndoRecord Record = TransformUndoStack_.back();
+        TransformUndoStack_.pop_back();
+        if (ApplyTransformUndoRecord(SceneManager, Record, false)) {
+            TransformRedoStack_.push_back(Record);
+        }
+    }
+}
+
 void ERS_CLASS_VisualRenderer::UpdateViewports(float DeltaTime, ERS_CLASS_SceneManager* SceneManager) {
 
     
@@ -116,6 +215,7 @@ void ERS_CLASS_VisualRenderer::UpdateViewports(float DeltaTime, ERS_CLASS_SceneM
 
 
     // Iterate Through Viewports
+    HandleTransformUndoShortcuts(SceneManager);
     for (int i = 0; (long)i < (long)Viewports_.size(); i++) {
         UpdateViewport(i, SceneManager, DeltaTime);
     }
@@ -464,42 +564,16 @@ void ERS_CLASS_VisualRenderer::UpdateViewport(int Index, ERS_CLASS_SceneManager*
             }
 
             // Get LocRotScale
-            glm::vec3 Position;        
-            glm::vec3 Rotation;      
+            glm::vec3 Position;
+            glm::vec3 Rotation;
             glm::vec3 Scale;
             bool HasRotation = false;
             bool HasScale = false;
 
-            if (Scene->SceneObjects_[SelectedObject].Type_ == std::string("Model")) {
-                unsigned long ModelIndex = Scene->SceneObjects_[SelectedObject].Index_;
-                Position = Scene->Models[ModelIndex]->ModelPosition;        
-                Rotation = Scene->Models[ModelIndex]->ModelRotation;        
-                Scale = Scene->Models[ModelIndex]->ModelScale;                
-                HasRotation = true;
-                HasScale = true;
-            } else if (Scene->SceneObjects_[SelectedObject].Type_ == std::string("PointLight")) {
-                unsigned long Index = Scene->SceneObjects_[SelectedObject].Index_;
-                Position = Scene->PointLights[Index]->Pos;        
-            } else if (Scene->SceneObjects_[SelectedObject].Type_ == std::string("DirectionalLight")) {
-                unsigned long Index = Scene->SceneObjects_[SelectedObject].Index_;
-                Position = Scene->DirectionalLights[Index]->Pos;        
-                Rotation = Scene->DirectionalLights[Index]->Rot;    
-                HasRotation = true;    
-            } else if (Scene->SceneObjects_[SelectedObject].Type_ == std::string("SpotLight")) {
-                unsigned long Index = Scene->SceneObjects_[SelectedObject].Index_;
-                Position = Scene->SpotLights[Index]->Pos;        
-                Rotation = Scene->SpotLights[Index]->Rot;    
-                HasRotation = true;    
-            } else if (Scene->SceneObjects_[SelectedObject].Type_ == std::string("SceneCamera")) {
-                unsigned long Index = Scene->SceneObjects_[SelectedObject].Index_;
-                Position = Scene->SceneCameras[Index]->Pos_;        
-                Rotation = Scene->SceneCameras[Index]->Rot_;    
-                HasRotation = true;    
-            }
-
-
             // Set Cursor Position        
-            Cursors3D_->SetLocRotScale(Position, Rotation, Scale, HasRotation, HasScale);
+            if (SceneManager->GetSelectedLocRotScale(Position, Rotation, Scale, HasRotation, HasScale)) {
+                Cursors3D_->SetLocRotScale(Position, Rotation, Scale, HasRotation, HasScale);
+            }
 
             // Indicate Selection Hasn't Changed
             Scene->HasSelectionChanged = false;
@@ -575,7 +649,9 @@ void ERS_CLASS_VisualRenderer::UpdateViewport(int Index, ERS_CLASS_SceneManager*
 
         }
 
-
+        if (DrawCursor && Cursors3D_->IsUsing() && !TransformUndoRecordActive_) {
+            BeginTransformUndoRecord(SceneManager);
+        }
 
         // Update Selected Object
         if (!Cursors3D_->HasObjectChanged_) {
@@ -583,6 +659,10 @@ void ERS_CLASS_VisualRenderer::UpdateViewport(int Index, ERS_CLASS_SceneManager*
         } else {
             Cursors3D_->HasObjectChanged_ = false;
             
+        }
+
+        if (TransformUndoRecordActive_ && !Cursors3D_->IsUsing()) {
+            FinishTransformUndoRecord(SceneManager);
         }
 
 
@@ -833,4 +913,3 @@ ERS_STRUCT_Viewport* Viewport) {
         ShaderUniformData_->SpotLights_[i].LightSpaceMatrix_ = ActiveScene->SpotLights[i]->DepthMap.TransformationMatrix;
     }
 }
-

--- a/Source/Core/Renderer/ERS_CLASS_VisualRenderer/VisualRenderer.h
+++ b/Source/Core/Renderer/ERS_CLASS_VisualRenderer/VisualRenderer.h
@@ -62,6 +62,19 @@ class ERS_CLASS_VisualRenderer {
 
 private:
 
+    struct ERS_STRUCT_TransformUndoRecord {
+        int SceneIndex = -1;
+        unsigned long SceneObjectIndex = 0;
+        glm::vec3 BeforePos = glm::vec3(0.0f);
+        glm::vec3 BeforeRot = glm::vec3(0.0f);
+        glm::vec3 BeforeScale = glm::vec3(1.0f);
+        glm::vec3 AfterPos = glm::vec3(0.0f);
+        glm::vec3 AfterRot = glm::vec3(0.0f);
+        glm::vec3 AfterScale = glm::vec3(1.0f);
+        bool HasRotation = false;
+        bool HasScale = false;
+    };
+
     GLFWwindow*                Window_             = nullptr; /**<GLFW Window Instance For Window Input To Viewports*/
     Cursors3D*                 Cursors3D_          = nullptr; /**<Setup 3D Cursor Class*/
     ERS_STRUCT_OpenGLDefaults* OpenGLDefaults_     = nullptr; /**<Pointer acquired from renderermanager*/
@@ -77,6 +90,11 @@ private:
 
     long int FrameNumber_               = 0; /**<Frame counter, starts at 0*/
     int      ActiveViewportCursorIndex_ = 0; /**<The index of the viewport which the gizmo is being interacted with*/
+    bool     TransformUndoRecordActive_ = false; /**<Indicates an active gizmo transform transaction*/
+
+    ERS_STRUCT_TransformUndoRecord              ActiveTransformUndoRecord_;
+    std::vector<ERS_STRUCT_TransformUndoRecord> TransformUndoStack_;
+    std::vector<ERS_STRUCT_TransformUndoRecord> TransformRedoStack_;
 
 
 public:
@@ -126,6 +144,38 @@ private:
      * @param DeltaTime 
      */
     void UpdateViewport(int Index, ERS_CLASS_SceneManager* SceneManager, float DeltaTime, bool DrawCursor = true);
+
+    /**
+     * @brief Handle undo/redo keyboard shortcuts for editor transform operations.
+     *
+     * @param SceneManager
+     */
+    void HandleTransformUndoShortcuts(ERS_CLASS_SceneManager* SceneManager);
+
+    /**
+     * @brief Begin recording a selected object transform transaction.
+     *
+     * @param SceneManager
+     */
+    void BeginTransformUndoRecord(ERS_CLASS_SceneManager* SceneManager);
+
+    /**
+     * @brief Finish recording a selected object transform transaction.
+     *
+     * @param SceneManager
+     */
+    void FinishTransformUndoRecord(ERS_CLASS_SceneManager* SceneManager);
+
+    /**
+     * @brief Apply a transform undo record.
+     *
+     * @param SceneManager
+     * @param Record
+     * @param ApplyAfter
+     * @return true
+     * @return false
+     */
+    bool ApplyTransformUndoRecord(ERS_CLASS_SceneManager* SceneManager, const ERS_STRUCT_TransformUndoRecord& Record, bool ApplyAfter);
 
 
 


### PR DESCRIPTION
Fixes #90.

## Summary
- add first-pass editor transform undo/redo for ImGuizmo moves, rotates, and scales
- centralize selected-object transform read/apply logic in `SceneManager` so undo can target models, lights, and scene cameras consistently
- fix selected spot-light transform updates so they apply to `SpotLights` instead of falling through the directional-light branch

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Notes
- This first pass covers gizmo transform transactions and keyboard shortcuts (`Ctrl/Cmd+Z`, `Ctrl/Cmd+Y`, `Ctrl/Cmd+Shift+Z`). Property-panel numeric edits are left for a follow-up so this PR stays isolated from the GUI files currently touched by other open PRs.

## Verification
- `git diff --check`
- `gh pr diff 509 --repo carboncopies/BrainGenix-ERS --patch | git apply --check --whitespace=error-all -` against a fresh `origin/master` export
- `cd Tools && bash Build.sh 4 Debug` (configuration fails locally because the vcpkg toolchain file is missing and CMake has no Make generator configured in this checkout)