### PR TITLE
Add scene tree grouping

### DIFF
--- a/Source/Core/Editor/Windows/GUI_Window_SceneTree/GUI_Window_SceneTree.cpp
+++ b/Source/Core/Editor/Windows/GUI_Window_SceneTree/GUI_Window_SceneTree.cpp
@@ -5,8 +5,11 @@
 #include <GUI_Window_SceneTree.h>
 
 // Standard Libraries (BG convention: use <> instead of "")
+// cppcheck-suppress missingIncludeSystem
 #include <algorithm>
+// cppcheck-suppress missingIncludeSystem
 #include <cstring>
+// cppcheck-suppress missingIncludeSystem
 #include <map>
 
 GUI_Window_SceneTree::GUI_Window_SceneTree(ERS_CLASS_SceneManager* SceneManager, ERS_STRUCT_SystemUtils* SystemUtils, ERS_STRUCT_ProjectUtils* ProjectUtils, Cursors3D* Cursors3D) {
@@ -374,7 +377,7 @@ void GUI_Window_SceneTree::DrawScene(ERS_STRUCT_Scene* Scene, int SceneIndex) {
                             TreeFlags |= ImGuiTreeNodeFlags_Selected;
                         }
 
-                        ImGui::TreeNodeEx((void*)(intptr_t)SceneObjectIndex, TreeFlags, "%s", ObjectName);
+                        ImGui::TreeNodeEx(reinterpret_cast<void*>(static_cast<intptr_t>(SceneObjectIndex)), TreeFlags, "%s", ObjectName);
                         if (ImGui::IsItemClicked()) {
                             Scene->SelectedObject = SceneObjectIndex;
                             Scene->HasSelectionChanged = true;

--- a/Source/Core/Editor/Windows/GUI_Window_SceneTree/GUI_Window_SceneTree.cpp
+++ b/Source/Core/Editor/Windows/GUI_Window_SceneTree/GUI_Window_SceneTree.cpp
@@ -4,6 +4,11 @@
 
 #include <GUI_Window_SceneTree.h>
 
+// Standard Libraries (BG convention: use <> instead of "")
+#include <algorithm>
+#include <cstring>
+#include <map>
+
 GUI_Window_SceneTree::GUI_Window_SceneTree(ERS_CLASS_SceneManager* SceneManager, ERS_STRUCT_SystemUtils* SystemUtils, ERS_STRUCT_ProjectUtils* ProjectUtils, Cursors3D* Cursors3D) {
 
     SceneManager_ = SceneManager;
@@ -33,6 +38,123 @@ GUI_Window_SceneTree::GUI_Window_SceneTree(ERS_CLASS_SceneManager* SceneManager,
 GUI_Window_SceneTree::~GUI_Window_SceneTree() {
 
 
+}
+
+std::string GUI_Window_SceneTree::GetSceneTreeGroup(ERS_STRUCT_Scene* Scene, unsigned long SceneObjectIndex) {
+
+    if (Scene == nullptr || SceneObjectIndex >= Scene->SceneObjects_.size()) {
+        return "";
+    }
+
+    ERS_STRUCT_SceneObject* SceneObject = &Scene->SceneObjects_[SceneObjectIndex];
+    unsigned long ObjectIndex = SceneObject->Index_;
+
+    if (SceneObject->Type_ == "Model" && ObjectIndex < Scene->Models.size()) {
+        return Scene->Models[ObjectIndex]->SceneTreeGroup_;
+    } else if (SceneObject->Type_ == "PointLight" && ObjectIndex < Scene->PointLights.size()) {
+        return Scene->PointLights[ObjectIndex]->SceneTreeGroup_;
+    } else if (SceneObject->Type_ == "DirectionalLight" && ObjectIndex < Scene->DirectionalLights.size()) {
+        return Scene->DirectionalLights[ObjectIndex]->SceneTreeGroup_;
+    } else if (SceneObject->Type_ == "SpotLight" && ObjectIndex < Scene->SpotLights.size()) {
+        return Scene->SpotLights[ObjectIndex]->SceneTreeGroup_;
+    } else if (SceneObject->Type_ == "SceneCamera" && ObjectIndex < Scene->SceneCameras.size()) {
+        return Scene->SceneCameras[ObjectIndex]->SceneTreeGroup_;
+    }
+
+    return "";
+}
+
+void GUI_Window_SceneTree::SetSceneTreeGroup(ERS_STRUCT_Scene* Scene, unsigned long SceneObjectIndex, std::string GroupName) {
+
+    if (Scene == nullptr || SceneObjectIndex >= Scene->SceneObjects_.size()) {
+        return;
+    }
+
+    ERS_STRUCT_SceneObject* SceneObject = &Scene->SceneObjects_[SceneObjectIndex];
+    unsigned long ObjectIndex = SceneObject->Index_;
+
+    if (SceneObject->Type_ == "Model" && ObjectIndex < Scene->Models.size()) {
+        Scene->Models[ObjectIndex]->SceneTreeGroup_ = GroupName;
+    } else if (SceneObject->Type_ == "PointLight" && ObjectIndex < Scene->PointLights.size()) {
+        Scene->PointLights[ObjectIndex]->SceneTreeGroup_ = GroupName;
+    } else if (SceneObject->Type_ == "DirectionalLight" && ObjectIndex < Scene->DirectionalLights.size()) {
+        Scene->DirectionalLights[ObjectIndex]->SceneTreeGroup_ = GroupName;
+    } else if (SceneObject->Type_ == "SpotLight" && ObjectIndex < Scene->SpotLights.size()) {
+        Scene->SpotLights[ObjectIndex]->SceneTreeGroup_ = GroupName;
+    } else if (SceneObject->Type_ == "SceneCamera" && ObjectIndex < Scene->SceneCameras.size()) {
+        Scene->SceneCameras[ObjectIndex]->SceneTreeGroup_ = GroupName;
+    }
+
+    Scene->HasSelectionChanged = true;
+}
+
+void GUI_Window_SceneTree::ActivateSceneTreeGroupEditor(ERS_STRUCT_Scene* Scene, int SceneIndex, unsigned long SceneObjectIndex) {
+
+    GroupEditSceneIndex_ = SceneIndex;
+    GroupEditSceneObjectIndex_ = SceneObjectIndex;
+
+    std::string ExistingGroup = GetSceneTreeGroup(Scene, SceneObjectIndex);
+    std::strncpy(SceneTreeGroupBuffer_, ExistingGroup.c_str(), sizeof(SceneTreeGroupBuffer_));
+    SceneTreeGroupBuffer_[sizeof(SceneTreeGroupBuffer_) - 1] = '\0';
+
+    GroupEditEnabled_ = true;
+    GroupEditFirstFrame_ = true;
+}
+
+void GUI_Window_SceneTree::DrawSceneTreeGroupContextItems(ERS_STRUCT_Scene* Scene, int SceneIndex, unsigned long SceneObjectIndex) {
+
+    std::string CurrentGroup = GetSceneTreeGroup(Scene, SceneObjectIndex);
+    if (!CurrentGroup.empty()) {
+        ImGui::Text("Group: %s", CurrentGroup.c_str());
+    }
+
+    if (ImGui::MenuItem("Set Scene Tree Group...")) {
+        ActivateSceneTreeGroupEditor(Scene, SceneIndex, SceneObjectIndex);
+    }
+    if (!CurrentGroup.empty() && ImGui::MenuItem("Clear Scene Tree Group")) {
+        SetSceneTreeGroup(Scene, SceneObjectIndex, "");
+    }
+}
+
+void GUI_Window_SceneTree::DrawSceneTreeGroupEditor() {
+
+    if (GroupEditEnabled_) {
+    ImGui::Begin("Set Scene Tree Group", &GroupEditEnabled_, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoCollapse);
+
+        ImGui::SetWindowFocus();
+
+        if (GroupEditFirstFrame_) {
+            ImGui::SetKeyboardFocusHere(0);
+            GroupEditFirstFrame_ = false;
+        }
+
+        ImGui::SetItemDefaultFocus();
+        ImGui::InputTextWithHint("Group", "Enter Scene Tree Group", SceneTreeGroupBuffer_, sizeof(SceneTreeGroupBuffer_));
+
+        ImGui::Separator();
+
+        if (ImGui::Button("Apply", ImVec2(120, 0))) {
+            if (GroupEditSceneIndex_ >= 0 && (unsigned long)GroupEditSceneIndex_ < SceneManager_->Scenes_.size()) {
+                SetSceneTreeGroup(SceneManager_->Scenes_[GroupEditSceneIndex_].get(), GroupEditSceneObjectIndex_, SceneTreeGroupBuffer_);
+            }
+            GroupEditEnabled_ = false;
+        }
+
+        ImGui::SameLine();
+        if (ImGui::Button("Clear", ImVec2(120, 0))) {
+            if (GroupEditSceneIndex_ >= 0 && (unsigned long)GroupEditSceneIndex_ < SceneManager_->Scenes_.size()) {
+                SetSceneTreeGroup(SceneManager_->Scenes_[GroupEditSceneIndex_].get(), GroupEditSceneObjectIndex_, "");
+            }
+            GroupEditEnabled_ = false;
+        }
+
+        ImGui::SameLine();
+        if (ImGui::Button("Cancel", ImVec2(120, 0)) || ImGui::IsKeyPressed(GLFW_KEY_ESCAPE)) {
+            GroupEditEnabled_ = false;
+        }
+
+    ImGui::End();
+    }
 }
 
 void GUI_Window_SceneTree::Draw() {
@@ -179,6 +301,7 @@ void GUI_Window_SceneTree::Draw() {
     Subwindow_DeleteDirectionalLight_->Draw();
     Subwindow_DeleteSpotLight_->Draw();
     Subwindow_ModelReplaceModal_->Draw();
+    DrawSceneTreeGroupEditor();
 
 }
 
@@ -228,6 +351,49 @@ void GUI_Window_SceneTree::DrawScene(ERS_STRUCT_Scene* Scene, int SceneIndex) {
 
 
 
+    // Draw Custom Scene Tree Groups
+    std::map<std::string, std::vector<unsigned long>> SceneTreeGroups;
+    for (unsigned long i = 0; i < Scene->SceneObjects_.size(); i++) {
+        std::string GroupName = GetSceneTreeGroup(Scene, i);
+        if (!GroupName.empty()) {
+            SceneTreeGroups[GroupName].push_back(i);
+        }
+    }
+
+    if (!SceneTreeGroups.empty()) {
+        bool GroupsTree = ImGui::TreeNodeEx("Groups", ImGuiTreeNodeFlags_OpenOnDoubleClick | ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_DefaultOpen);
+        if (GroupsTree) {
+            for (auto const& Group : SceneTreeGroups) {
+                ImGui::PushID(Group.first.c_str());
+                bool GroupTree = ImGui::TreeNodeEx("SceneTreeGroup", ImGuiTreeNodeFlags_OpenOnDoubleClick | ImGuiTreeNodeFlags_OpenOnArrow, "%s (%lu)", Group.first.c_str(), Group.second.size());
+                if (GroupTree) {
+                    for (unsigned long SceneObjectIndex : Group.second) {
+                        const char* ObjectName = Scene->SceneObjects_[SceneObjectIndex].Label_.c_str();
+                        ImGuiTreeNodeFlags TreeFlags = ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen;
+                        if ((unsigned long)SelectedSceneObjectIndex == SceneObjectIndex) {
+                            TreeFlags |= ImGuiTreeNodeFlags_Selected;
+                        }
+
+                        ImGui::TreeNodeEx((void*)(intptr_t)SceneObjectIndex, TreeFlags, "%s", ObjectName);
+                        if (ImGui::IsItemClicked()) {
+                            Scene->SelectedObject = SceneObjectIndex;
+                            Scene->HasSelectionChanged = true;
+                        }
+
+                        if (ImGui::BeginPopupContextItem()) {
+                            DrawSceneTreeGroupContextItems(Scene, SceneIndex, SceneObjectIndex);
+                            ImGui::EndPopup();
+                        }
+                    }
+                    ImGui::TreePop();
+                }
+                ImGui::PopID();
+            }
+            ImGui::TreePop();
+        }
+    }
+
+
     // Draw Model Entries
     bool ModelTree = ImGui::TreeNodeEx("Models", ImGuiTreeNodeFlags_OpenOnDoubleClick | ImGuiTreeNodeFlags_OpenOnArrow);
 
@@ -265,7 +431,7 @@ void GUI_Window_SceneTree::DrawScene(ERS_STRUCT_Scene* Scene, int SceneIndex) {
                 }
 
                 // Next, Sort List Of Model Names
-                sort(ModelNames.begin(), ModelNames.end());
+                std::sort(ModelNames.begin(), ModelNames.end());
 
                 // Then, Re-Order Based On Sorted Model Name List
                 std::vector<std::shared_ptr<ERS_STRUCT_Model>> SortedList;
@@ -302,7 +468,6 @@ void GUI_Window_SceneTree::DrawScene(ERS_STRUCT_Scene* Scene, int SceneIndex) {
 
             unsigned long IndexInSceneObjects = ModelIndexes[i];
 
-
             const char* ObjectName = Scene->SceneObjects_[IndexInSceneObjects].Label_.c_str();
             ImGuiTreeNodeFlags TreeFlags = ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen;
             if ((unsigned long)SelectedSceneObjectIndex == IndexInSceneObjects) {
@@ -310,14 +475,11 @@ void GUI_Window_SceneTree::DrawScene(ERS_STRUCT_Scene* Scene, int SceneIndex) {
             }
             ImGui::TreeNodeEx((void*)(intptr_t)i, TreeFlags, "%s", ObjectName);
 
-
             // If User Clicks Node, Update Object Index
             if (ImGui::IsItemClicked()) {
                 Scene->SelectedObject = IndexInSceneObjects;
                 Scene->HasSelectionChanged = true;
             }
-
-
 
             // Drag/Drop Target
             long PayloadID;
@@ -326,9 +488,9 @@ void GUI_Window_SceneTree::DrawScene(ERS_STRUCT_Scene* Scene, int SceneIndex) {
                 if (const ImGuiPayload* Payload = ImGui::AcceptDragDropPayload("PAYLOAD_ASSET_SCRIPT_ID")) {
                     memcpy(&PayloadID, Payload->Data, sizeof(long));
                     SystemUtils_->Logger_->Log(std::string("Window_SceneTree Recieved Drag Drop Payload 'PAYLOAD_ASSET_SCRIPT_ID' With Value '") + std::to_string(PayloadID) + std::string("'"), 0);
-                    
+
                     // Check If Already In Vector
-                    bool Contains = false; 
+                    bool Contains = false;
                     for (unsigned long x = 0; x < Scene->Models[i]->AttachedScriptIndexes_.size(); x++) {
                         if (PayloadID ==  Scene->Models[i]->AttachedScriptIndexes_[x]) {
                             SystemUtils_->Logger_->Log(std::string("Window_SceneTree Error Assigning Payload 'PAYLOAD_ASSET_SCRIPT_ID' To 'Model', Already Attached").c_str(), 0);
@@ -344,7 +506,6 @@ void GUI_Window_SceneTree::DrawScene(ERS_STRUCT_Scene* Scene, int SceneIndex) {
 
             ImGui::EndDragDropTarget();
             }
-
 
             // Context Menu
             if (ImGui::BeginPopupContextItem()) {
@@ -373,14 +534,14 @@ void GUI_Window_SceneTree::DrawScene(ERS_STRUCT_Scene* Scene, int SceneIndex) {
 
                 }
                 ImGui::Separator();
+                DrawSceneTreeGroupContextItems(Scene, SceneIndex, IndexInSceneObjects);
+                ImGui::Separator();
                 if (ImGui::MenuItem("Delete")) {
                     Subwindow_DeleteModel_->DeleteModel(SceneIndex, i);
                 }
 
             ImGui::EndPopup();
             }
-
-
         }
 
     ImGui::TreePop();
@@ -448,6 +609,8 @@ void GUI_Window_SceneTree::DrawScene(ERS_STRUCT_Scene* Scene, int SceneIndex) {
                 if (ImGui::MenuItem("Duplicate")) {
                     GUI_Windowutil_DuplicatePointLight(SceneManager_, SceneIndex, i);
                 }
+                ImGui::Separator();
+                DrawSceneTreeGroupContextItems(Scene, SceneIndex, IndexInSceneObjects);
                 ImGui::Separator();
                 if (ImGui::MenuItem("Delete")) {
                     Subwindow_DeletePointLight_->DeletePointLight(SceneIndex, i);
@@ -519,6 +682,8 @@ void GUI_Window_SceneTree::DrawScene(ERS_STRUCT_Scene* Scene, int SceneIndex) {
                     GUI_Windowutil_DuplicateDirectionalLight(SceneManager_, SceneIndex, i);
                 }
                 ImGui::Separator();
+                DrawSceneTreeGroupContextItems(Scene, SceneIndex, IndexInSceneObjects);
+                ImGui::Separator();
                 if (ImGui::MenuItem("Delete")) {
                     Subwindow_DeleteDirectionalLight_->DeleteDirectionalLight(SceneIndex, i);
                 }
@@ -589,6 +754,8 @@ void GUI_Window_SceneTree::DrawScene(ERS_STRUCT_Scene* Scene, int SceneIndex) {
                     GUI_Windowutil_DuplicateSpotLight(SceneManager_, SceneIndex, i);
                 }
                 ImGui::Separator();
+                DrawSceneTreeGroupContextItems(Scene, SceneIndex, IndexInSceneObjects);
+                ImGui::Separator();
                 if (ImGui::MenuItem("Delete")) {
                     Subwindow_DeleteSpotLight_->DeleteSpotLight(SceneIndex, i);
                 }
@@ -658,19 +825,11 @@ void GUI_Window_SceneTree::DrawScene(ERS_STRUCT_Scene* Scene, int SceneIndex) {
             }
 
 
-            // // Context Menu
-            // if (ImGui::BeginPopupContextItem()) {
-
-            //     if (ImGui::MenuItem("Rename")) {
-            //         Subwindow_SceneCameraRenameModal_->Activate(SceneIndex, i);
-            //     }
-            //     ImGui::Separator();
-            //     if (ImGui::MenuItem("Delete")) {
-            //         Subwindow_DeleteSceneCamera_->DeleteSceneCamera(SceneIndex, i);
-            //     }
-
-            // ImGui::EndPopup();
-            // }
+            // Context Menu
+            if (ImGui::BeginPopupContextItem(std::string(std::string("SceneCamera")+std::to_string(i)).c_str())) {
+                DrawSceneTreeGroupContextItems(Scene, SceneIndex, IndexInSceneObjects);
+                ImGui::EndPopup();
+            }
 
 
         }
@@ -680,4 +839,3 @@ void GUI_Window_SceneTree::DrawScene(ERS_STRUCT_Scene* Scene, int SceneIndex) {
 
 
 }
-

--- a/Source/Core/Editor/Windows/GUI_Window_SceneTree/GUI_Window_SceneTree.h
+++ b/Source/Core/Editor/Windows/GUI_Window_SceneTree/GUI_Window_SceneTree.h
@@ -6,6 +6,7 @@
 
 
 // Standard Libraries (BG convention: use <> instead of "")
+#include <string>
 
 // Third-Party Libraries (BG convention: use <> instead of "")
 #include <glad/glad.h>
@@ -58,6 +59,11 @@ private:
     ERS_STRUCT_ProjectUtils* ProjectUtils_; /**<ProjectUtils Pointer*/
     Cursors3D* Cursors3D_; /**<Pointer to Cursors3D Instance*/
     bool FirstFrame_ = true; /**<Bool Indicating if It's the first frame*/
+    char SceneTreeGroupBuffer_[128] = "";
+    bool GroupEditEnabled_ = false;
+    bool GroupEditFirstFrame_ = false;
+    int GroupEditSceneIndex_ = -1;
+    unsigned long GroupEditSceneObjectIndex_ = 0;
 
 
 
@@ -88,6 +94,48 @@ private:
      * @param SceneIndex
      */
     void DrawScene(ERS_STRUCT_Scene* Scene, int SceneIndex);
+
+    /**
+     * @brief Draw menu actions for assigning scene tree groups.
+     *
+     * @param Scene
+     * @param SceneIndex
+     * @param SceneObjectIndex
+     */
+    void DrawSceneTreeGroupContextItems(ERS_STRUCT_Scene* Scene, int SceneIndex, unsigned long SceneObjectIndex);
+
+    /**
+     * @brief Open the scene tree group editor for a scene object.
+     *
+     * @param Scene
+     * @param SceneIndex
+     * @param SceneObjectIndex
+     */
+    void ActivateSceneTreeGroupEditor(ERS_STRUCT_Scene* Scene, int SceneIndex, unsigned long SceneObjectIndex);
+
+    /**
+     * @brief Draw the scene tree group editor.
+     *
+     */
+    void DrawSceneTreeGroupEditor();
+
+    /**
+     * @brief Get the group string for a scene object.
+     *
+     * @param Scene
+     * @param SceneObjectIndex
+     * @return std::string
+     */
+    std::string GetSceneTreeGroup(ERS_STRUCT_Scene* Scene, unsigned long SceneObjectIndex);
+
+    /**
+     * @brief Set the group string for a scene object.
+     *
+     * @param Scene
+     * @param SceneObjectIndex
+     * @param GroupName
+     */
+    void SetSceneTreeGroup(ERS_STRUCT_Scene* Scene, unsigned long SceneObjectIndex, std::string GroupName);
 
 
 

--- a/Source/Core/Loader/ERS_SceneLoader/SceneDecoderV6.cpp
+++ b/Source/Core/Loader/ERS_SceneLoader/SceneDecoderV6.cpp
@@ -38,6 +38,9 @@ bool ERS_FUNCTION_DecodeSceneV6(YAML::Node SceneData, ERS_STRUCT_Scene *Scene, E
         Success &= ERS_FUNCTION_GetBool       (Logger, Item, "TreatMissingTexturesAsTransparent", Model.TreatMissingTexturesAsTransparent_ );
         Success &= ERS_FUNCTION_GetLong       (Logger, Item, "ShaderOverrideIndex",               Model.ShaderOverrideIndex_               );
         Success &= ERS_FUNCTION_GetString     (Logger, Item, "AssetName",                         Model.Name                               );
+        if (Item["SceneTreeGroup"]) {
+            Success &= ERS_FUNCTION_GetString (Logger, Item, "SceneTreeGroup",                    Model.SceneTreeGroup_                    );
+        }
         Success &= ERS_FUNCTION_GetLongVector (Logger, Item, "AttachedScripts",                   Model.AttachedScriptIndexes_             );
         Success &= ERS_FUNCTION_GetInt        (Logger, Item, "ModelMinLOD",                       Model.UserLimitedMinLOD_                 );
         Success &= ERS_FUNCTION_GetInt        (Logger, Item, "ModelMaxLOD",                       Model.UserLimitedMaxLOD_                 );
@@ -57,6 +60,9 @@ bool ERS_FUNCTION_DecodeSceneV6(YAML::Node SceneData, ERS_STRUCT_Scene *Scene, E
         YAML::Node Item = PointLights[i];
         ERS_STRUCT_PointLight Light;
         Success &= ERS_FUNCTION_GetString     (Logger, Item, "AssetName",            Light.UserDefinedName         );
+        if (Item["SceneTreeGroup"]) {
+            Success &= ERS_FUNCTION_GetString (Logger, Item, "SceneTreeGroup",       Light.SceneTreeGroup_         );
+        }
         Success &= ERS_FUNCTION_GetVec3Color  (Logger, Item, "Color",                Light.Color                   );
         Success &= ERS_FUNCTION_GetVec3       (Logger, Item, "Pos",                  Light.Pos                     );
         Success &= ERS_FUNCTION_GetFloat      (Logger, Item, "Intensity",            Light.Intensity               );
@@ -71,6 +77,9 @@ bool ERS_FUNCTION_DecodeSceneV6(YAML::Node SceneData, ERS_STRUCT_Scene *Scene, E
         YAML::Node Item = SpotLights[i];
         ERS_STRUCT_SpotLight Light;
         Success &= ERS_FUNCTION_GetString     (Logger, Item, "AssetName",            Light.UserDefinedName         );
+        if (Item["SceneTreeGroup"]) {
+            Success &= ERS_FUNCTION_GetString (Logger, Item, "SceneTreeGroup",       Light.SceneTreeGroup_         );
+        }
         Success &= ERS_FUNCTION_GetVec3Color  (Logger, Item, "Color",                Light.Color                   );
         Success &= ERS_FUNCTION_GetVec3       (Logger, Item, "Pos",                  Light.Pos                     );
         Success &= ERS_FUNCTION_GetVec3       (Logger, Item, "Rot",                  Light.Rot                     );
@@ -89,6 +98,9 @@ bool ERS_FUNCTION_DecodeSceneV6(YAML::Node SceneData, ERS_STRUCT_Scene *Scene, E
         YAML::Node Item = DirectionalLights[i];
         ERS_STRUCT_DirectionalLight Light;
         Success &= ERS_FUNCTION_GetString     (Logger, Item, "AssetName",            Light.UserDefinedName         );
+        if (Item["SceneTreeGroup"]) {
+            Success &= ERS_FUNCTION_GetString (Logger, Item, "SceneTreeGroup",       Light.SceneTreeGroup_         );
+        }
         Success &= ERS_FUNCTION_GetVec3Color  (Logger, Item, "Color",                Light.Color                   );
         Success &= ERS_FUNCTION_GetVec3       (Logger, Item, "Pos",                  Light.Pos                     );
         Success &= ERS_FUNCTION_GetVec3       (Logger, Item, "Rot",                  Light.Rot                     );
@@ -105,6 +117,9 @@ bool ERS_FUNCTION_DecodeSceneV6(YAML::Node SceneData, ERS_STRUCT_Scene *Scene, E
         YAML::Node Item = SceneCameras[i];
         ERS_STRUCT_SceneCamera Camera;
         Success &= ERS_FUNCTION_GetString     (Logger, Item, "AssetName",            Camera.UserDefinedName_       );
+        if (Item["SceneTreeGroup"]) {
+            Success &= ERS_FUNCTION_GetString (Logger, Item, "SceneTreeGroup",       Camera.SceneTreeGroup_        );
+        }
         Success &= ERS_FUNCTION_GetVec3       (Logger, Item, "Pos",                  Camera.Pos_                   );
         Success &= ERS_FUNCTION_GetVec3       (Logger, Item, "Rot",                  Camera.Rot_                   );
         Success &= ERS_FUNCTION_GetFloat      (Logger, Item, "NearClip",             Camera.NearClip_              );
@@ -129,5 +144,4 @@ bool ERS_FUNCTION_DecodeSceneV6(YAML::Node SceneData, ERS_STRUCT_Scene *Scene, E
     Scene->IsSceneLoaded = Success;
     return Success;
 }
-
 

--- a/Source/Core/Structures/ERS_STRUCT_Light/DirectionalLight.h
+++ b/Source/Core/Structures/ERS_STRUCT_Light/DirectionalLight.h
@@ -18,6 +18,7 @@
 struct ERS_STRUCT_DirectionalLight {
 
     std::string UserDefinedName; /**Name of the light assigned by user*/
+    std::string SceneTreeGroup_; /**<Optional editor-only scene tree group name*/
     
     std::vector<long> AttachedScriptIndexes_; /**<Indexes of attached scripts (index in the project struct's list of scripts)*/
 

--- a/Source/Core/Structures/ERS_STRUCT_Light/PointLight.h
+++ b/Source/Core/Structures/ERS_STRUCT_Light/PointLight.h
@@ -19,6 +19,7 @@
 struct ERS_STRUCT_PointLight {
 
     std::string UserDefinedName; /**Name of the light assigned by user*/
+    std::string SceneTreeGroup_; /**<Optional editor-only scene tree group name*/
     
     float Intensity; /**<Intensity of the light*/
     float MaxDistance; /**<Distance After Which This Light No Longer Affects The Scene*/

--- a/Source/Core/Structures/ERS_STRUCT_Light/SpotLight.h
+++ b/Source/Core/Structures/ERS_STRUCT_Light/SpotLight.h
@@ -19,6 +19,7 @@
 struct ERS_STRUCT_SpotLight {
 
     std::string UserDefinedName; /**Name of the light assigned by user*/
+    std::string SceneTreeGroup_; /**<Optional editor-only scene tree group name*/
     
     float Intensity; /**<Intensity of the light*/
     float MaxDistance; /**<Distance After Which This Light No Longer Affects The Scene*/

--- a/Source/Core/Structures/ERS_STRUCT_Model/Model.h
+++ b/Source/Core/Structures/ERS_STRUCT_Model/Model.h
@@ -5,6 +5,7 @@
 #pragma once
 
 // Standard Libraries (BG convention: use <> instead of "")
+#include <string>
 #include <vector>
 
 // Third-Party Libraries (BG convention: use <> instead of "")
@@ -73,6 +74,7 @@ struct ERS_STRUCT_Model {
     bool TexturesBeingPushed = false; /**<Used to set if the system is already pushing textures*/
 
     std::vector<long> AttachedScriptIndexes_; /**<Indexes of attached scripts (index in the project struct's list of scripts)*/
+    std::string SceneTreeGroup_; /**<Optional editor-only scene tree group name*/
 
     double LoadingStartTime_     = 0.0f; /**<Time that the loading started*/
     double LoadingFinishTime_    = 0.0f; /**<Time When Loading Was Completed*/
@@ -210,6 +212,4 @@ struct ERS_STRUCT_Model {
 
 
 };
-
-
 

--- a/Source/Core/Structures/ERS_STRUCT_SceneCamera/SceneCamera.h
+++ b/Source/Core/Structures/ERS_STRUCT_SceneCamera/SceneCamera.h
@@ -28,6 +28,7 @@ struct ERS_STRUCT_SceneCamera {
     float             FarClip_               = 100.0f; /**<Farthest distance before geometry is called*/
     std::vector<long> AttachedScriptIndexes_;          /**<Indices of scripts that are attached to this camera*/
     std::string       UserDefinedName_;                /**<Name that appears in the editor's scene tree*/
+    std::string       SceneTreeGroup_;                 /**<Optional editor-only scene tree group name*/
 
     // Internal Camera State Information
     float FOV_               = 70.0f; /**<Field of view in degrees*/

--- a/Source/Core/Writers/ERS_SceneWriter/SceneWriter.cpp
+++ b/Source/Core/Writers/ERS_SceneWriter/SceneWriter.cpp
@@ -67,6 +67,7 @@ std::string SceneWriter::ProcessScene(ERS_STRUCT_Scene* InputScene) {
         Output << YAML::Key << "AssetName" << YAML::Value << InputScene->Models[i]->Name;
         Output << YAML::Key << "AssetType" << YAML::Value << "Model";
         Output << YAML::Key << "AssetID" << YAML::Value << InputScene->Models[i]->AssetID;
+        Output << YAML::Key << "SceneTreeGroup" << YAML::Value << InputScene->Models[i]->SceneTreeGroup_;
 
 
         Output << YAML::Key << "AssetPositionX" << YAML::Value << InputScene->Models[i]->ModelPosition[0];
@@ -119,6 +120,7 @@ std::string SceneWriter::ProcessScene(ERS_STRUCT_Scene* InputScene) {
 
         Output << YAML::Key << "AssetName" << YAML::Value << InputScene->DirectionalLights[i]->UserDefinedName;
         Output << YAML::Key << "AssetType" << YAML::Value << "DirectionalLight";
+        Output << YAML::Key << "SceneTreeGroup" << YAML::Value << InputScene->DirectionalLights[i]->SceneTreeGroup_;
 
 
         Output << YAML::Key << "ColorRed" << YAML::Value << InputScene->DirectionalLights[i]->Color[0];
@@ -161,6 +163,7 @@ std::string SceneWriter::ProcessScene(ERS_STRUCT_Scene* InputScene) {
 
         Output << YAML::Key << "AssetName" << YAML::Value << InputScene->PointLights[i]->UserDefinedName;
         Output << YAML::Key << "AssetType" << YAML::Value << "PointLight";
+        Output << YAML::Key << "SceneTreeGroup" << YAML::Value << InputScene->PointLights[i]->SceneTreeGroup_;
 
 
         Output << YAML::Key << "ColorRed" << YAML::Value << InputScene->PointLights[i]->Color[0];
@@ -203,6 +206,7 @@ std::string SceneWriter::ProcessScene(ERS_STRUCT_Scene* InputScene) {
 
         Output << YAML::Key << "AssetName" << YAML::Value << InputScene->SpotLights[i]->UserDefinedName;
         Output << YAML::Key << "AssetType" << YAML::Value << "SpotLight";
+        Output << YAML::Key << "SceneTreeGroup" << YAML::Value << InputScene->SpotLights[i]->SceneTreeGroup_;
 
 
         Output << YAML::Key << "ColorRed" << YAML::Value << InputScene->SpotLights[i]->Color[0];
@@ -256,6 +260,7 @@ std::string SceneWriter::ProcessScene(ERS_STRUCT_Scene* InputScene) {
 
         Output << YAML::Key << "AssetName" << YAML::Value << SceneCamera->UserDefinedName_;
         Output << YAML::Key << "AssetType" << YAML::Value << "SceneCamera";
+        Output << YAML::Key << "SceneTreeGroup" << YAML::Value << SceneCamera->SceneTreeGroup_;
 
         Output << YAML::Key << "PosX" << YAML::Value << SceneCamera->Pos_[0];
         Output << YAML::Key << "PosY" << YAML::Value << SceneCamera->Pos_[1];
@@ -296,4 +301,3 @@ std::string SceneWriter::ProcessScene(ERS_STRUCT_Scene* InputScene) {
     return std::string(Output.c_str());
 
 }
-


### PR DESCRIPTION
## Summary
- Adds persistent `SceneTreeGroup_` metadata to models, scene cameras, and all light types.
- Adds a scene tree `Groups` section plus context menu actions to set or clear an object group.
- Saves and optionally loads `SceneTreeGroup` in v6 scene YAML so old scenes still load.

## Notes
- The grouped view is additive: existing Models, Lights, and Cameras sections remain unchanged for rename, duplicate, delete, and drag/drop workflows.
- I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `git diff --check`
- `cd Tools && bash Build.sh 4 Debug` fails during configure in this checkout because `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` is missing and CMake has no `Unix Makefiles` build program configured.

Fixes #105