### PR TITLE
Add editor menu localization

### DIFF
--- a/Source/Core/Editor/Menus/EditorLocalization.h
+++ b/Source/Core/Editor/Menus/EditorLocalization.h
@@ -1,0 +1,367 @@
+//======================================================================//
+// This file is part of the BrainGenix-ERS Environment Rendering System //
+//======================================================================//
+
+#pragma once
+
+namespace ERS::Editor::Localization {
+
+enum class Language {
+    English = 0,
+    French,
+    Russian,
+    Chinese
+};
+
+enum class TextID {
+    File,
+    New,
+    Open,
+    Save,
+    ProjectSettings,
+    About,
+    ImportModel,
+    ImportModelsInDirectory,
+    Exit,
+
+    Window,
+    Windows,
+    SceneTree,
+    SystemLog,
+    AssetExplorer,
+    ObjectProperties,
+    Framerate,
+    FramerateCounter,
+    FramerateHistogram,
+    FramerateGraph,
+    FrameratePlot,
+    FrameLatencyGraph,
+    SystemResources,
+    RAM,
+    Viewport,
+    AddViewport,
+    RemoveViewport,
+    ScriptEditor,
+    ShaderEditor,
+
+    Settings,
+    ColorTheme,
+    SystemFont,
+    Language,
+    EditorSettings,
+    EditorCameraSettings,
+    EngineSettings,
+    RenderingSettings,
+    AssetStreamingSettings,
+    GameControllers,
+    DetectNewControllers,
+    GameControllerSettings,
+
+    Debug,
+    ImGuiDemoWindow,
+    TestEditorWindow,
+    InduceSegmentationFault,
+    WindowManagerDebugging,
+    ShowAllWindows,
+    HideAllWindows,
+    InvertWindowStates,
+    OpenGLDebugging,
+    DebuggingEnabled,
+    GLSources,
+    GLTypes,
+    GLSeverity
+};
+
+inline Language ActiveLanguage = Language::English;
+
+inline const char* GetLanguageName(int Index) {
+    switch ((Language)Index) {
+        case Language::English:
+            return "English";
+        case Language::French:
+            return "Français";
+        case Language::Russian:
+            return "Русский";
+        case Language::Chinese:
+            return "中文";
+    }
+    return "English";
+}
+
+inline int GetLanguageCount() {
+    return 4;
+}
+
+inline int GetActiveLanguageIndex() {
+    return (int)ActiveLanguage;
+}
+
+inline void SetActiveLanguageFromIndex(int Index) {
+    if (Index >= 0 && Index < GetLanguageCount()) {
+        ActiveLanguage = (Language)Index;
+    }
+}
+
+inline const char* GetEnglish(TextID ID) {
+    switch (ID) {
+        case TextID::File:                    return "File";
+        case TextID::New:                     return "New";
+        case TextID::Open:                    return "Open";
+        case TextID::Save:                    return "Save";
+        case TextID::ProjectSettings:         return "Project Settings";
+        case TextID::About:                   return "About";
+        case TextID::ImportModel:             return "Import Model";
+        case TextID::ImportModelsInDirectory: return "Import Models In Directory";
+        case TextID::Exit:                    return "Exit";
+
+        case TextID::Window:                  return "Window";
+        case TextID::Windows:                 return "Windows";
+        case TextID::SceneTree:               return "Scene Tree";
+        case TextID::SystemLog:               return "System Log";
+        case TextID::AssetExplorer:           return "Asset Explorer";
+        case TextID::ObjectProperties:        return "Object Properties";
+        case TextID::Framerate:               return "Framerate";
+        case TextID::FramerateCounter:        return "Framerate Counter";
+        case TextID::FramerateHistogram:      return "Framerate Histogram";
+        case TextID::FramerateGraph:          return "Framerate Graph";
+        case TextID::FrameratePlot:           return "Framerate Plot";
+        case TextID::FrameLatencyGraph:       return "Frame Latency Graph";
+        case TextID::SystemResources:         return "System Resources";
+        case TextID::RAM:                     return "RAM";
+        case TextID::Viewport:                return "Viewport";
+        case TextID::AddViewport:             return "Add Viewport";
+        case TextID::RemoveViewport:          return "Remove Viewport";
+        case TextID::ScriptEditor:            return "Script Editor";
+        case TextID::ShaderEditor:            return "Shader Editor";
+
+        case TextID::Settings:                return "Settings";
+        case TextID::ColorTheme:              return "Color Theme";
+        case TextID::SystemFont:              return "System Font";
+        case TextID::Language:                return "Language";
+        case TextID::EditorSettings:          return "Editor Settings";
+        case TextID::EditorCameraSettings:    return "Editor Camera Settings";
+        case TextID::EngineSettings:          return "Engine Settings";
+        case TextID::RenderingSettings:       return "Rendering Settings";
+        case TextID::AssetStreamingSettings:  return "Asset Streaming Settings";
+        case TextID::GameControllers:         return "Game Controllers";
+        case TextID::DetectNewControllers:    return "Detect New Controllers";
+        case TextID::GameControllerSettings:  return "Game Controller Settings";
+
+        case TextID::Debug:                   return "Debug";
+        case TextID::ImGuiDemoWindow:         return "ImGui Demo Window";
+        case TextID::TestEditorWindow:        return "Test Editor Window";
+        case TextID::InduceSegmentationFault: return "Induce Segmentation Fault";
+        case TextID::WindowManagerDebugging:  return "Window Manager Debugging";
+        case TextID::ShowAllWindows:          return "Show All Windows";
+        case TextID::HideAllWindows:          return "Hide All Windows";
+        case TextID::InvertWindowStates:      return "Invert Window States";
+        case TextID::OpenGLDebugging:         return "OpenGL Debugging";
+        case TextID::DebuggingEnabled:        return "Debugging Enabled";
+        case TextID::GLSources:               return "GL Sources";
+        case TextID::GLTypes:                 return "GL Types";
+        case TextID::GLSeverity:              return "GL Severity";
+    }
+    return "";
+}
+
+inline const char* GetFrench(TextID ID) {
+    switch (ID) {
+        case TextID::File:                    return "Fichier";
+        case TextID::New:                     return "Nouveau";
+        case TextID::Open:                    return "Ouvrir";
+        case TextID::Save:                    return "Enregistrer";
+        case TextID::ProjectSettings:         return "Paramètres du projet";
+        case TextID::About:                   return "À propos";
+        case TextID::ImportModel:             return "Importer un modèle";
+        case TextID::ImportModelsInDirectory: return "Importer les modèles du dossier";
+        case TextID::Exit:                    return "Quitter";
+
+        case TextID::Window:                  return "Fenêtre";
+        case TextID::Windows:                 return "Fenêtres";
+        case TextID::SceneTree:               return "Arborescence de scène";
+        case TextID::SystemLog:               return "Journal système";
+        case TextID::AssetExplorer:           return "Explorateur d'actifs";
+        case TextID::ObjectProperties:        return "Propriétés de l'objet";
+        case TextID::Framerate:               return "Fréquence d'images";
+        case TextID::FramerateCounter:        return "Compteur FPS";
+        case TextID::FramerateHistogram:      return "Histogramme FPS";
+        case TextID::FramerateGraph:          return "Graphique FPS";
+        case TextID::FrameratePlot:           return "Courbe FPS";
+        case TextID::FrameLatencyGraph:       return "Latence d'image";
+        case TextID::SystemResources:         return "Ressources système";
+        case TextID::RAM:                     return "RAM";
+        case TextID::Viewport:                return "Vue";
+        case TextID::AddViewport:             return "Ajouter une vue";
+        case TextID::RemoveViewport:          return "Supprimer une vue";
+        case TextID::ScriptEditor:            return "Éditeur de scripts";
+        case TextID::ShaderEditor:            return "Éditeur de shaders";
+
+        case TextID::Settings:                return "Paramètres";
+        case TextID::ColorTheme:              return "Thème de couleur";
+        case TextID::SystemFont:              return "Police système";
+        case TextID::Language:                return "Langue";
+        case TextID::EditorSettings:          return "Paramètres de l'éditeur";
+        case TextID::EditorCameraSettings:    return "Paramètres de caméra";
+        case TextID::EngineSettings:          return "Paramètres du moteur";
+        case TextID::RenderingSettings:       return "Paramètres de rendu";
+        case TextID::AssetStreamingSettings:  return "Paramètres de streaming";
+        case TextID::GameControllers:         return "Manettes";
+        case TextID::DetectNewControllers:    return "Détecter les manettes";
+        case TextID::GameControllerSettings:  return "Paramètres des manettes";
+
+        case TextID::Debug:                   return "Débogage";
+        case TextID::ImGuiDemoWindow:         return "Fenêtre de démonstration ImGui";
+        case TextID::TestEditorWindow:        return "Fenêtre d'éditeur de test";
+        case TextID::InduceSegmentationFault: return "Provoquer une erreur mémoire";
+        case TextID::WindowManagerDebugging:  return "Débogage du gestionnaire de fenêtres";
+        case TextID::ShowAllWindows:          return "Afficher toutes les fenêtres";
+        case TextID::HideAllWindows:          return "Masquer toutes les fenêtres";
+        case TextID::InvertWindowStates:      return "Inverser les états";
+        case TextID::OpenGLDebugging:         return "Débogage OpenGL";
+        case TextID::DebuggingEnabled:        return "Débogage activé";
+        case TextID::GLSources:               return "Sources GL";
+        case TextID::GLTypes:                 return "Types GL";
+        case TextID::GLSeverity:              return "Gravité GL";
+    }
+    return GetEnglish(ID);
+}
+
+inline const char* GetRussian(TextID ID) {
+    switch (ID) {
+        case TextID::File:                    return "Файл";
+        case TextID::New:                     return "Новый";
+        case TextID::Open:                    return "Открыть";
+        case TextID::Save:                    return "Сохранить";
+        case TextID::ProjectSettings:         return "Настройки проекта";
+        case TextID::About:                   return "О программе";
+        case TextID::ImportModel:             return "Импорт модели";
+        case TextID::ImportModelsInDirectory: return "Импорт моделей из папки";
+        case TextID::Exit:                    return "Выход";
+
+        case TextID::Window:                  return "Окно";
+        case TextID::Windows:                 return "Окна";
+        case TextID::SceneTree:               return "Дерево сцены";
+        case TextID::SystemLog:               return "Системный журнал";
+        case TextID::AssetExplorer:           return "Обозреватель ресурсов";
+        case TextID::ObjectProperties:        return "Свойства объекта";
+        case TextID::Framerate:               return "Частота кадров";
+        case TextID::FramerateCounter:        return "Счётчик FPS";
+        case TextID::FramerateHistogram:      return "Гистограмма FPS";
+        case TextID::FramerateGraph:          return "График FPS";
+        case TextID::FrameratePlot:           return "Кривая FPS";
+        case TextID::FrameLatencyGraph:       return "Задержка кадра";
+        case TextID::SystemResources:         return "Системные ресурсы";
+        case TextID::RAM:                     return "ОЗУ";
+        case TextID::Viewport:                return "Область просмотра";
+        case TextID::AddViewport:             return "Добавить область";
+        case TextID::RemoveViewport:          return "Удалить область";
+        case TextID::ScriptEditor:            return "Редактор скриптов";
+        case TextID::ShaderEditor:            return "Редактор шейдеров";
+
+        case TextID::Settings:                return "Настройки";
+        case TextID::ColorTheme:              return "Цветовая тема";
+        case TextID::SystemFont:              return "Системный шрифт";
+        case TextID::Language:                return "Язык";
+        case TextID::EditorSettings:          return "Настройки редактора";
+        case TextID::EditorCameraSettings:    return "Настройки камеры";
+        case TextID::EngineSettings:          return "Настройки движка";
+        case TextID::RenderingSettings:       return "Настройки рендеринга";
+        case TextID::AssetStreamingSettings:  return "Настройки потоковой загрузки";
+        case TextID::GameControllers:         return "Игровые контроллеры";
+        case TextID::DetectNewControllers:    return "Найти новые контроллеры";
+        case TextID::GameControllerSettings:  return "Настройки контроллеров";
+
+        case TextID::Debug:                   return "Отладка";
+        case TextID::ImGuiDemoWindow:         return "Демо-окно ImGui";
+        case TextID::TestEditorWindow:        return "Тестовое окно редактора";
+        case TextID::InduceSegmentationFault: return "Вызвать ошибку сегментации";
+        case TextID::WindowManagerDebugging:  return "Отладка менеджера окон";
+        case TextID::ShowAllWindows:          return "Показать все окна";
+        case TextID::HideAllWindows:          return "Скрыть все окна";
+        case TextID::InvertWindowStates:      return "Инвертировать состояния";
+        case TextID::OpenGLDebugging:         return "Отладка OpenGL";
+        case TextID::DebuggingEnabled:        return "Отладка включена";
+        case TextID::GLSources:               return "Источники GL";
+        case TextID::GLTypes:                 return "Типы GL";
+        case TextID::GLSeverity:              return "Важность GL";
+    }
+    return GetEnglish(ID);
+}
+
+inline const char* GetChinese(TextID ID) {
+    switch (ID) {
+        case TextID::File:                    return "文件";
+        case TextID::New:                     return "新建";
+        case TextID::Open:                    return "打开";
+        case TextID::Save:                    return "保存";
+        case TextID::ProjectSettings:         return "项目设置";
+        case TextID::About:                   return "关于";
+        case TextID::ImportModel:             return "导入模型";
+        case TextID::ImportModelsInDirectory: return "导入文件夹中的模型";
+        case TextID::Exit:                    return "退出";
+
+        case TextID::Window:                  return "窗口";
+        case TextID::Windows:                 return "窗口列表";
+        case TextID::SceneTree:               return "场景树";
+        case TextID::SystemLog:               return "系统日志";
+        case TextID::AssetExplorer:           return "资源浏览器";
+        case TextID::ObjectProperties:        return "对象属性";
+        case TextID::Framerate:               return "帧率";
+        case TextID::FramerateCounter:        return "帧率计数器";
+        case TextID::FramerateHistogram:      return "帧率直方图";
+        case TextID::FramerateGraph:          return "帧率图";
+        case TextID::FrameratePlot:           return "帧率曲线";
+        case TextID::FrameLatencyGraph:       return "帧延迟图";
+        case TextID::SystemResources:         return "系统资源";
+        case TextID::RAM:                     return "内存";
+        case TextID::Viewport:                return "视口";
+        case TextID::AddViewport:             return "添加视口";
+        case TextID::RemoveViewport:          return "移除视口";
+        case TextID::ScriptEditor:            return "脚本编辑器";
+        case TextID::ShaderEditor:            return "着色器编辑器";
+
+        case TextID::Settings:                return "设置";
+        case TextID::ColorTheme:              return "颜色主题";
+        case TextID::SystemFont:              return "系统字体";
+        case TextID::Language:                return "语言";
+        case TextID::EditorSettings:          return "编辑器设置";
+        case TextID::EditorCameraSettings:    return "编辑器相机设置";
+        case TextID::EngineSettings:          return "引擎设置";
+        case TextID::RenderingSettings:       return "渲染设置";
+        case TextID::AssetStreamingSettings:  return "资源流式加载设置";
+        case TextID::GameControllers:         return "游戏控制器";
+        case TextID::DetectNewControllers:    return "检测新控制器";
+        case TextID::GameControllerSettings:  return "游戏控制器设置";
+
+        case TextID::Debug:                   return "调试";
+        case TextID::ImGuiDemoWindow:         return "ImGui 演示窗口";
+        case TextID::TestEditorWindow:        return "测试编辑器窗口";
+        case TextID::InduceSegmentationFault: return "触发段错误";
+        case TextID::WindowManagerDebugging:  return "窗口管理器调试";
+        case TextID::ShowAllWindows:          return "显示所有窗口";
+        case TextID::HideAllWindows:          return "隐藏所有窗口";
+        case TextID::InvertWindowStates:      return "反转窗口状态";
+        case TextID::OpenGLDebugging:         return "OpenGL 调试";
+        case TextID::DebuggingEnabled:        return "启用调试";
+        case TextID::GLSources:               return "GL 来源";
+        case TextID::GLTypes:                 return "GL 类型";
+        case TextID::GLSeverity:              return "GL 严重性";
+    }
+    return GetEnglish(ID);
+}
+
+inline const char* Get(TextID ID) {
+    switch (ActiveLanguage) {
+        case Language::English:
+            return GetEnglish(ID);
+        case Language::French:
+            return GetFrench(ID);
+        case Language::Russian:
+            return GetRussian(ID);
+        case Language::Chinese:
+            return GetChinese(ID);
+    }
+    return GetEnglish(ID);
+}
+
+}

--- a/Source/Core/Editor/Menus/GUI_Menu_Debug/CMakeLists.txt
+++ b/Source/Core/Editor/Menus/GUI_Menu_Debug/CMakeLists.txt
@@ -39,4 +39,4 @@ target_link_libraries(Menu_Debug
 
     )
 
-target_include_directories(Menu_Debug PUBLIC ./)
+target_include_directories(Menu_Debug PUBLIC ./ ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/Source/Core/Editor/Menus/GUI_Menu_Debug/GUI_Menu_Debug.cpp
+++ b/Source/Core/Editor/Menus/GUI_Menu_Debug/GUI_Menu_Debug.cpp
@@ -3,6 +3,7 @@
 //======================================================================//
 
 #include <GUI_Menu_Debug.h>
+// cppcheck-suppress missingIncludeSystem
 #include <EditorLocalization.h>
 
 namespace Localization = ERS::Editor::Localization;

--- a/Source/Core/Editor/Menus/GUI_Menu_Debug/GUI_Menu_Debug.cpp
+++ b/Source/Core/Editor/Menus/GUI_Menu_Debug/GUI_Menu_Debug.cpp
@@ -3,7 +3,9 @@
 //======================================================================//
 
 #include <GUI_Menu_Debug.h>
+#include <EditorLocalization.h>
 
+namespace Localization = ERS::Editor::Localization;
 
 // Constructor
 GUI_Menu_Debug::GUI_Menu_Debug(ERS_STRUCT_SystemUtils* SystemUtils, ERS_STRUCT_Windows* Windows, ERS_CLASS_WindowManager* WindowManager) {
@@ -37,20 +39,20 @@ void GUI_Menu_Debug::Draw() {
     if (DebugMenuEnabled_) {
 
         // Debug Menu
-        if (ImGui::BeginMenu("Debug")) {
+        if (ImGui::BeginMenu(Localization::Get(Localization::TextID::Debug))) {
 
 
             // Debugging Tools Menu
-            if (ImGui::MenuItem("ImGui Demo Window")) {
+            if (ImGui::MenuItem(Localization::Get(Localization::TextID::ImGuiDemoWindow))) {
                 ShowImGuiDemoWindow_ = !ShowImGuiDemoWindow_;
             }
 
             // Test Editor
-            ImGui::MenuItem("Test Editor Window", "", &Windows_->GUI_Window_TestEditor_->Enabled_);
+            ImGui::MenuItem(Localization::Get(Localization::TextID::TestEditorWindow), "", &Windows_->GUI_Window_TestEditor_->Enabled_);
 
 
             // Segfault Button
-            if (ImGui::MenuItem("Induce Segmentation Fault")) {
+            if (ImGui::MenuItem(Localization::Get(Localization::TextID::InduceSegmentationFault))) {
                 int* ThisWillCrash = nullptr;
                 int Something = *ThisWillCrash;
                 Something++;
@@ -61,9 +63,9 @@ void GUI_Menu_Debug::Draw() {
             ImGui::Separator();
 
             // Window Manager Debug stuff - show, hide, toggle windows.
-            if (ImGui::BeginMenu("Window Manager Debugging")) {
+            if (ImGui::BeginMenu(Localization::Get(Localization::TextID::WindowManagerDebugging))) {
 
-                if (ImGui::MenuItem("Show All Windows")) {
+                if (ImGui::MenuItem(Localization::Get(Localization::TextID::ShowAllWindows))) {
 
                     std::vector<std::string> WindowNames = WindowManager_->GetWindowNames();
                     for (unsigned int i = 0; i < WindowNames.size(); i++) {
@@ -75,7 +77,7 @@ void GUI_Menu_Debug::Draw() {
 
                 }
 
-                if (ImGui::MenuItem("Hide All Windows")) {
+                if (ImGui::MenuItem(Localization::Get(Localization::TextID::HideAllWindows))) {
 
                     std::vector<std::string> WindowNames = WindowManager_->GetWindowNames();
                     for (unsigned int i = 0; i < WindowNames.size(); i++) {
@@ -87,7 +89,7 @@ void GUI_Menu_Debug::Draw() {
 
                 }
 
-                if (ImGui::MenuItem("Invert Window States")) {
+                if (ImGui::MenuItem(Localization::Get(Localization::TextID::InvertWindowStates))) {
 
                     std::vector<std::string> WindowNames = WindowManager_->GetWindowNames();
                     for (unsigned int i = 0; i < WindowNames.size(); i++) {
@@ -107,7 +109,7 @@ void GUI_Menu_Debug::Draw() {
 
 
             // OpenGL Debug Submenu
-            if (ImGui::BeginMenu("OpenGL Debugging")) {
+            if (ImGui::BeginMenu(Localization::Get(Localization::TextID::OpenGLDebugging))) {
                 ERS_CLASS_OpenGLDebug_->DrawMenu();
             ImGui::EndMenu();
             }

--- a/Source/Core/Editor/Menus/GUI_Menu_Debug/OpenGLDebug.cpp
+++ b/Source/Core/Editor/Menus/GUI_Menu_Debug/OpenGLDebug.cpp
@@ -3,6 +3,7 @@
 //======================================================================//
 
 #include <OpenGLDebug.h>
+// cppcheck-suppress missingIncludeSystem
 #include <EditorLocalization.h>
 
 namespace Localization = ERS::Editor::Localization;

--- a/Source/Core/Editor/Menus/GUI_Menu_Debug/OpenGLDebug.cpp
+++ b/Source/Core/Editor/Menus/GUI_Menu_Debug/OpenGLDebug.cpp
@@ -3,7 +3,9 @@
 //======================================================================//
 
 #include <OpenGLDebug.h>
+#include <EditorLocalization.h>
 
+namespace Localization = ERS::Editor::Localization;
 
 ERS_CLASS_OpenGLDebug::ERS_CLASS_OpenGLDebug(ERS_STRUCT_SystemUtils* SystemUtils) {
 
@@ -26,14 +28,14 @@ ERS_CLASS_OpenGLDebug::~ERS_CLASS_OpenGLDebug() {
 
 void ERS_CLASS_OpenGLDebug::DrawMenu() {
 
-    if (ImGui::MenuItem("Debugging Enabled", "", &DebugEnabled_)) {
+    if (ImGui::MenuItem(Localization::Get(Localization::TextID::DebuggingEnabled), "", &DebugEnabled_)) {
         ERS_OpenGLLoggingSystem_->SetCollectionStatus(DebugEnabled_);
     }
 
     ImGui::Separator();
 
     // Source Submenu
-    if (ImGui::BeginMenu("GL Sources")) {
+    if (ImGui::BeginMenu(Localization::Get(Localization::TextID::GLSources))) {
 
         if (ImGui::MenuItem("GL_DEBUG_SOURCE_API", "", &ERS_OpenGLLoggingSystem_->LogSourceApi_)) {
             ERS_OpenGLLoggingSystem_->SetCollectionStatus(DebugEnabled_);
@@ -58,7 +60,7 @@ void ERS_CLASS_OpenGLDebug::DrawMenu() {
     }
 
     // Type Submenu
-    if (ImGui::BeginMenu("GL Types")) {
+    if (ImGui::BeginMenu(Localization::Get(Localization::TextID::GLTypes))) {
 
         if (ImGui::MenuItem("GL_DEBUG_TYPE_ERROR", "", &ERS_OpenGLLoggingSystem_->LogTypeError_)) {
             ERS_OpenGLLoggingSystem_->SetCollectionStatus(DebugEnabled_);
@@ -92,7 +94,7 @@ void ERS_CLASS_OpenGLDebug::DrawMenu() {
     }
 
     // Severity Submenu
-    if (ImGui::BeginMenu("GL Severity")) {
+    if (ImGui::BeginMenu(Localization::Get(Localization::TextID::GLSeverity))) {
 
         if (ImGui::MenuItem("GL_DEBUG_SEVERITY_HIGH", "", &ERS_OpenGLLoggingSystem_->LogSeverityHigh_)) {
             ERS_OpenGLLoggingSystem_->SetCollectionStatus(DebugEnabled_);

--- a/Source/Core/Editor/Menus/GUI_Menu_File/CMakeLists.txt
+++ b/Source/Core/Editor/Menus/GUI_Menu_File/CMakeLists.txt
@@ -40,4 +40,4 @@ target_link_libraries(Menu_File
     ERS_CLASS_VisualRenderer
     )
 
-target_include_directories(Menu_File PUBLIC ./)
+target_include_directories(Menu_File PUBLIC ./ ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/Source/Core/Editor/Menus/GUI_Menu_File/GUI_Menu_File.cpp
+++ b/Source/Core/Editor/Menus/GUI_Menu_File/GUI_Menu_File.cpp
@@ -3,6 +3,7 @@
 //======================================================================//
 
 #include <GUI_Menu_File.h>
+// cppcheck-suppress missingIncludeSystem
 #include <EditorLocalization.h>
 
 namespace Localization = ERS::Editor::Localization;

--- a/Source/Core/Editor/Menus/GUI_Menu_File/GUI_Menu_File.cpp
+++ b/Source/Core/Editor/Menus/GUI_Menu_File/GUI_Menu_File.cpp
@@ -3,7 +3,9 @@
 //======================================================================//
 
 #include <GUI_Menu_File.h>
+#include <EditorLocalization.h>
 
+namespace Localization = ERS::Editor::Localization;
 
 GUI_Menu_File::GUI_Menu_File(ERS_STRUCT_SystemUtils* SystemUtils, ERS_CLASS_SceneManager* SceneManager, ERS_STRUCT_ProjectUtils* ProjectUtils, ERS_STRUCT_Windows* Windows) {
 
@@ -28,15 +30,15 @@ GUI_Menu_File::~GUI_Menu_File() {
 void GUI_Menu_File::Draw() {
 
     // File Menu
-    if (ImGui::BeginMenu("File")) {
+    if (ImGui::BeginMenu(Localization::Get(Localization::TextID::File))) {
 
-        ImGui::MenuItem("New", "", &Windows_->GUI_Window_NewProject_->Enabled_);
-        ImGui::MenuItem("Open", "", &Windows_->GUI_Window_OpenProject_->Enabled_);
+        ImGui::MenuItem(Localization::Get(Localization::TextID::New), "", &Windows_->GUI_Window_NewProject_->Enabled_);
+        ImGui::MenuItem(Localization::Get(Localization::TextID::Open), "", &Windows_->GUI_Window_OpenProject_->Enabled_);
         ImGui::Separator();
 
 
         ImGui::Separator();
-        if (ImGui::MenuItem("Save")) {
+        if (ImGui::MenuItem(Localization::Get(Localization::TextID::Save))) {
 
             SystemUtils_->Logger_->Log("Saving Project Data", 4);
             ProjectUtils_->ProjectManager_->WriteProject(1);
@@ -51,18 +53,18 @@ void GUI_Menu_File::Draw() {
             }
         }
 
-        ImGui::MenuItem("Project Settings", "", &Windows_->GUI_Window_ProjectSettings_->Enabled_);
-        ImGui::MenuItem("About", "", &Windows_->GUI_Window_About_->Enabled_);
+        ImGui::MenuItem(Localization::Get(Localization::TextID::ProjectSettings), "", &Windows_->GUI_Window_ProjectSettings_->Enabled_);
+        ImGui::MenuItem(Localization::Get(Localization::TextID::About), "", &Windows_->GUI_Window_About_->Enabled_);
 
         ImGui::Separator();
 
-        ImGui::MenuItem("Import Model", "", &Windows_->GUI_Window_ImportModel_->Enabled_);
-        ImGui::MenuItem("Import Models In Directory", "", &Windows_->GUI_Window_ImportModelDirectory_->Enabled_);
+        ImGui::MenuItem(Localization::Get(Localization::TextID::ImportModel), "", &Windows_->GUI_Window_ImportModel_->Enabled_);
+        ImGui::MenuItem(Localization::Get(Localization::TextID::ImportModelsInDirectory), "", &Windows_->GUI_Window_ImportModelDirectory_->Enabled_);
 
         ImGui::Separator();
 
         // Exit Options
-        if (ImGui::MenuItem("Exit")) {
+        if (ImGui::MenuItem(Localization::Get(Localization::TextID::Exit))) {
             *SystemUtils_->SystemShouldRun_ = false;
         }
 

--- a/Source/Core/Editor/Menus/GUI_Menu_Settings/CMakeLists.txt
+++ b/Source/Core/Editor/Menus/GUI_Menu_Settings/CMakeLists.txt
@@ -32,4 +32,4 @@ target_link_libraries(Menu_Settings
 
     )
 
-target_include_directories(Menu_Settings PUBLIC ./)
+target_include_directories(Menu_Settings PUBLIC ./ ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/Source/Core/Editor/Menus/GUI_Menu_Settings/GUI_Menu_Settings.cpp
+++ b/Source/Core/Editor/Menus/GUI_Menu_Settings/GUI_Menu_Settings.cpp
@@ -3,7 +3,9 @@
 //======================================================================//
 
 #include <GUI_Menu_Settings.h>
+#include <EditorLocalization.h>
 
+namespace Localization = ERS::Editor::Localization;
 
 GUI_Menu_Settings::GUI_Menu_Settings(ERS_STRUCT_SystemUtils* SystemUtils, ERS_STRUCT_HumanInputDeviceUtils* HIDUtils, ERS_STRUCT_Windows* Windows) {
 
@@ -26,35 +28,44 @@ GUI_Menu_Settings::~GUI_Menu_Settings() {
 void GUI_Menu_Settings::Draw() {
 
     // File Menu
-    if (ImGui::BeginMenu("Settings")) {
+    if (ImGui::BeginMenu(Localization::Get(Localization::TextID::Settings))) {
 
         // Interface Config
-        ImGui::MenuItem("Color Theme", "", &Windows_->GUI_Window_ThemeSelector_->Enabled_);
-        ImGui::MenuItem("System Font", "", &Windows_->GUI_Window_FontSelector_->Enabled_);
-
-        ImGui::Separator();
-        if (ImGui::BeginMenu("Editor Settings")) {
-            ImGui::MenuItem("Editor Camera Settings", "", &Windows_->GUI_Window_EditorCameraSettings_->Enabled_);
+        ImGui::MenuItem(Localization::Get(Localization::TextID::ColorTheme), "", &Windows_->GUI_Window_ThemeSelector_->Enabled_);
+        ImGui::MenuItem(Localization::Get(Localization::TextID::SystemFont), "", &Windows_->GUI_Window_FontSelector_->Enabled_);
+        if (ImGui::BeginMenu(Localization::Get(Localization::TextID::Language))) {
+            for (int i = 0; i < Localization::GetLanguageCount(); i++) {
+                bool IsSelected = i == Localization::GetActiveLanguageIndex();
+                if (ImGui::MenuItem(Localization::GetLanguageName(i), "", IsSelected)) {
+                    Localization::SetActiveLanguageFromIndex(i);
+                }
+            }
         ImGui::EndMenu();
         }
 
         ImGui::Separator();
-        if (ImGui::BeginMenu("Engine Settings")) {
-            ImGui::MenuItem("Rendering Settings", "", &Windows_->GUI_Window_RenderingSettings_->Enabled_);
-            ImGui::MenuItem("Asset Streaming Settings", "", &Windows_->GUI_Window_AssetStreamingSettings_->Enabled_);
+        if (ImGui::BeginMenu(Localization::Get(Localization::TextID::EditorSettings))) {
+            ImGui::MenuItem(Localization::Get(Localization::TextID::EditorCameraSettings), "", &Windows_->GUI_Window_EditorCameraSettings_->Enabled_);
         ImGui::EndMenu();
         }
 
         ImGui::Separator();
-        if (ImGui::BeginMenu("Game Controllers")) {
+        if (ImGui::BeginMenu(Localization::Get(Localization::TextID::EngineSettings))) {
+            ImGui::MenuItem(Localization::Get(Localization::TextID::RenderingSettings), "", &Windows_->GUI_Window_RenderingSettings_->Enabled_);
+            ImGui::MenuItem(Localization::Get(Localization::TextID::AssetStreamingSettings), "", &Windows_->GUI_Window_AssetStreamingSettings_->Enabled_);
+        ImGui::EndMenu();
+        }
+
+        ImGui::Separator();
+        if (ImGui::BeginMenu(Localization::Get(Localization::TextID::GameControllers))) {
 
             // Refresh
-            if (ImGui::MenuItem("Detect New Controllers")) {
+            if (ImGui::MenuItem(Localization::Get(Localization::TextID::DetectNewControllers))) {
                 HIDUtils_->ControllerInputManager->DetectControllers();
             }
 
             // Open Settings MEnu
-            ImGui::MenuItem("Game Controller Settings", "", &Windows_->GUI_Window_ControllerSettings_->Enabled_);
+            ImGui::MenuItem(Localization::Get(Localization::TextID::GameControllerSettings), "", &Windows_->GUI_Window_ControllerSettings_->Enabled_);
 
         ImGui::EndMenu();
         }

--- a/Source/Core/Editor/Menus/GUI_Menu_Settings/GUI_Menu_Settings.cpp
+++ b/Source/Core/Editor/Menus/GUI_Menu_Settings/GUI_Menu_Settings.cpp
@@ -3,6 +3,7 @@
 //======================================================================//
 
 #include <GUI_Menu_Settings.h>
+// cppcheck-suppress missingIncludeSystem
 #include <EditorLocalization.h>
 
 namespace Localization = ERS::Editor::Localization;

--- a/Source/Core/Editor/Menus/GUI_Menu_Window/CMakeLists.txt
+++ b/Source/Core/Editor/Menus/GUI_Menu_Window/CMakeLists.txt
@@ -50,4 +50,4 @@ target_link_libraries(Menu_Window
 
     )
 
-target_include_directories(Menu_Window PUBLIC ./)
+target_include_directories(Menu_Window PUBLIC ./ ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/Source/Core/Editor/Menus/GUI_Menu_Window/GUI_Menu_Window.cpp
+++ b/Source/Core/Editor/Menus/GUI_Menu_Window/GUI_Menu_Window.cpp
@@ -3,7 +3,9 @@
 //======================================================================//
 
 #include <GUI_Menu_Window.h>
+#include <EditorLocalization.h>
 
+namespace Localization = ERS::Editor::Localization;
 
 GUI_Menu_Window::GUI_Menu_Window(ERS_STRUCT_SystemUtils* SystemUtils, ERS_STRUCT_Windows* Windows,  ERS_CLASS_VisualRenderer* VisualRendererInstance) {
 
@@ -25,37 +27,37 @@ GUI_Menu_Window::~GUI_Menu_Window() {
 void GUI_Menu_Window::Draw() {
 
     // Window Menu
-    if (ImGui::BeginMenu("Window")) {
+    if (ImGui::BeginMenu(Localization::Get(Localization::TextID::Window))) {
 
 
 
         // Add Windows Menu
-        if (ImGui::BeginMenu("Windows")) {
+        if (ImGui::BeginMenu(Localization::Get(Localization::TextID::Windows))) {
 
             // Add Scene Tree Editor Window
-            ImGui::MenuItem("Scene Tree", "", &Windows_->GUI_Window_SceneTree_->Enabled_);
-            ImGui::MenuItem("System Log", "", &Windows_->GUI_Window_SystemLog_->Enabled_);
-            ImGui::MenuItem("Asset Explorer", "", &Windows_->GUI_Window_AssetExplorer_->Enabled_);
-            ImGui::MenuItem("Object Properties", "", &Windows_->GUI_Window_ObjectProperties_->Enabled_);
+            ImGui::MenuItem(Localization::Get(Localization::TextID::SceneTree), "", &Windows_->GUI_Window_SceneTree_->Enabled_);
+            ImGui::MenuItem(Localization::Get(Localization::TextID::SystemLog), "", &Windows_->GUI_Window_SystemLog_->Enabled_);
+            ImGui::MenuItem(Localization::Get(Localization::TextID::AssetExplorer), "", &Windows_->GUI_Window_AssetExplorer_->Enabled_);
+            ImGui::MenuItem(Localization::Get(Localization::TextID::ObjectProperties), "", &Windows_->GUI_Window_ObjectProperties_->Enabled_);
 
             // Framerate Widgets
-            if (ImGui::BeginMenu("Framerate")) {
+            if (ImGui::BeginMenu(Localization::Get(Localization::TextID::Framerate))) {
 
                 // Framerate Related Tools
-                ImGui::MenuItem("Framerate Counter", "", &Windows_->GUI_Window_FramerateCounter_->Enabled_);
-                ImGui::MenuItem("Framerate Histogram", "", &Windows_->GUI_Window_FramerateHistogram_->Enabled_);
-                ImGui::MenuItem("Framerate Graph", "", &Windows_->GUI_Window_FramerateGraph_->Enabled_);
-                ImGui::MenuItem("Framerate Plot", "", &Windows_->GUI_Window_FrameratePlot_->Enabled_);
-                ImGui::MenuItem("Frame Latency Graph", "", &Windows_->GUI_Window_FrameLatencyGraph_->Enabled_);
+                ImGui::MenuItem(Localization::Get(Localization::TextID::FramerateCounter), "", &Windows_->GUI_Window_FramerateCounter_->Enabled_);
+                ImGui::MenuItem(Localization::Get(Localization::TextID::FramerateHistogram), "", &Windows_->GUI_Window_FramerateHistogram_->Enabled_);
+                ImGui::MenuItem(Localization::Get(Localization::TextID::FramerateGraph), "", &Windows_->GUI_Window_FramerateGraph_->Enabled_);
+                ImGui::MenuItem(Localization::Get(Localization::TextID::FrameratePlot), "", &Windows_->GUI_Window_FrameratePlot_->Enabled_);
+                ImGui::MenuItem(Localization::Get(Localization::TextID::FrameLatencyGraph), "", &Windows_->GUI_Window_FrameLatencyGraph_->Enabled_);
 
             ImGui::EndMenu();
             }
 
             // System Resource Widgets
-            if (ImGui::BeginMenu("System Resources")) {
+            if (ImGui::BeginMenu(Localization::Get(Localization::TextID::SystemResources))) {
 
                 // Framerate Related Tools
-                ImGui::MenuItem("RAM", "", &Windows_->GUI_Window_RAMGraph_->Enabled_);
+                ImGui::MenuItem(Localization::Get(Localization::TextID::RAM), "", &Windows_->GUI_Window_RAMGraph_->Enabled_);
 
             ImGui::EndMenu();
             }
@@ -67,14 +69,14 @@ void GUI_Menu_Window::Draw() {
         }
 
         // Viewport Menu
-        if (ImGui::BeginMenu("Viewport")) {
+        if (ImGui::BeginMenu(Localization::Get(Localization::TextID::Viewport))) {
 
             // Viewport Options
-            if (ImGui::MenuItem("Add Viewport")) {
+            if (ImGui::MenuItem(Localization::Get(Localization::TextID::AddViewport))) {
                 VisualRenderer_->CreateViewport();
             }
 
-            if (ImGui::MenuItem("Remove Viewport")) {
+            if (ImGui::MenuItem(Localization::Get(Localization::TextID::RemoveViewport))) {
                 if (VisualRenderer_->Viewports_.size() > 0) {
                     VisualRenderer_->DeleteViewport(VisualRenderer_->Viewports_.size()-1);
                 }
@@ -85,8 +87,8 @@ void GUI_Menu_Window::Draw() {
         ImGui::EndMenu();
         }
 
-        ImGui::MenuItem("Script Editor", "", &Windows_->GUI_Window_ScriptEditor_->Enabled_);
-        ImGui::MenuItem("Shader Editor", "", &Windows_->GUI_Window_ShaderEditor_->Enabled_);
+        ImGui::MenuItem(Localization::Get(Localization::TextID::ScriptEditor), "", &Windows_->GUI_Window_ScriptEditor_->Enabled_);
+        ImGui::MenuItem(Localization::Get(Localization::TextID::ShaderEditor), "", &Windows_->GUI_Window_ShaderEditor_->Enabled_);
 
 
     ImGui::EndMenu();

--- a/Source/Core/Editor/Menus/GUI_Menu_Window/GUI_Menu_Window.cpp
+++ b/Source/Core/Editor/Menus/GUI_Menu_Window/GUI_Menu_Window.cpp
@@ -3,6 +3,7 @@
 //======================================================================//
 
 #include <GUI_Menu_Window.h>
+// cppcheck-suppress missingIncludeSystem
 #include <EditorLocalization.h>
 
 namespace Localization = ERS::Editor::Localization;


### PR DESCRIPTION
## Summary
- Adds a first-pass editor menu localization table with English, French, Russian, and Chinese labels.
- Adds a runtime language selector under Settings > Language.
- Wires the File, Window, Settings, and Debug menus to localized labels while leaving OpenGL enum constants unchanged.

## Notes
- This is scoped to editor menus so it avoids unrelated window, renderer, and main-loop changes.
- I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `git diff --check`
- `printf ... | c++ -std=c++20 -fsyntax-only -x c++ -` for `EditorLocalization.h`
- `cmake -S . -B Build/ers-273-check -DCMAKE_BUILD_TYPE=Debug` fails during configure in this checkout because `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` is missing and CMake has no `Unix Makefiles` build program configured.
- `cd Tools && bash Build.sh 4 Debug` fails because the existing build directory has no generated Make command in this checkout.

Fixes #273