### PR TITLE
Harden controller disconnect handling

### DIFF
--- a/Source/Core/Editor/Windows/GUI_Window_ControllerSettings/GUI_Window_ControllerSettings.cpp
+++ b/Source/Core/Editor/Windows/GUI_Window_ControllerSettings/GUI_Window_ControllerSettings.cpp
@@ -54,10 +54,28 @@ void GUI_Window_ControllerSettings::Draw() {
 
                     // Active Selected Controller Dropdown
                     int NumberControllers = HIDUtils_->ControllerInputManager->NumberControllers_;
+                    if (NumberControllers > (int)HIDUtils_->ControllerInputManager->ControllerStates_.size()) {
+                        NumberControllers = (int)HIDUtils_->ControllerInputManager->ControllerStates_.size();
+                    }
+                    if (NumberControllers > (int)HIDUtils_->ControllerInputManager->ControllerNames_.size()) {
+                        NumberControllers = (int)HIDUtils_->ControllerInputManager->ControllerNames_.size();
+                    }
+                    if (NumberControllers > 16) {
+                        NumberControllers = 16;
+                    }
+                    if (NumberControllers <= 0) {
+                        SelectedController_ = 0;
+                    } else if (SelectedController_ >= NumberControllers) {
+                        SelectedController_ = NumberControllers - 1;
+                    } else if (SelectedController_ < 0) {
+                        SelectedController_ = 0;
+                    }
                     for (int i = 0; i < NumberControllers; i++) {
                         ControllerNames_[i] = HIDUtils_->ControllerInputManager->ControllerNames_[i].c_str();
                     }
-                    ImGui::Combo("Selected Controller", &SelectedController_, ControllerNames_, NumberControllers, NumberControllers);
+                    if (NumberControllers > 0) {
+                        ImGui::Combo("Selected Controller", &SelectedController_, ControllerNames_, NumberControllers, NumberControllers);
+                    }
                     ImGui::Separator();
 
 
@@ -146,8 +164,12 @@ void GUI_Window_ControllerSettings::Draw() {
 
 
                     // Update Controller Dropdown List And Index
-                    if ((long)SelectedControllerProfile_ > (long)ControllerSettings->size()) {
+                    if (ControllerSettings->size() == 0) {
+                        SelectedControllerProfile_ = 0;
+                    } else if ((long)SelectedControllerProfile_ >= (long)ControllerSettings->size()) {
                         SelectedControllerProfile_ = (int)ControllerSettings->size() - 1;
+                    } else if (SelectedControllerProfile_ < 0) {
+                        SelectedControllerProfile_ = 0;
                     }
 
                     for (int i = 0; (long)i < (long)ControllerSettings->size(); i++) {
@@ -159,7 +181,9 @@ void GUI_Window_ControllerSettings::Draw() {
                         if (ImGui::Button("Delete Profile")) {
                             ProjectUtils_->ProjectManager_->Project_.ControllerSettings->erase(ProjectUtils_->ProjectManager_->Project_.ControllerSettings->begin() + SelectedControllerProfile_);
                             ProjectUtils_->ProjectManager_->Project_.GameControllerSettingsIDs.erase(ProjectUtils_->ProjectManager_->Project_.GameControllerSettingsIDs.begin() + SelectedControllerProfile_);
-                            SelectedControllerProfile_--;
+                            if (SelectedControllerProfile_ > 0) {
+                                SelectedControllerProfile_--;
+                            }
                         }
                     }
                     if (ControllerSettings->size() < 128) {
@@ -170,7 +194,9 @@ void GUI_Window_ControllerSettings::Draw() {
                         }
                     }
                     ImGui::SameLine();
-                    ImGui::Combo("Selected Controller Profile", &SelectedControllerProfile_, ControllerProfileNames_, ControllerSettings->size(),  ControllerSettings->size());
+                    if (ControllerSettings->size() > 0) {
+                        ImGui::Combo("Selected Controller Profile", &SelectedControllerProfile_, ControllerProfileNames_, ControllerSettings->size(),  ControllerSettings->size());
+                    }
 
                     ImGui::Separator();
 

--- a/Source/Core/Manager/ERS_ControllerManager/ControllerInputManager.cpp
+++ b/Source/Core/Manager/ERS_ControllerManager/ControllerInputManager.cpp
@@ -28,9 +28,12 @@ void ERS_CLASS_ControllerInputManager::UpdateNumberInputDevices() {
 
     // Iterate Through All 16 Supported Controllers
     NumberInputDevices_ = 0;
-    for (int i = 0; i < 16; i++) {
+    InputDeviceIDs_.erase(InputDeviceIDs_.begin(), InputDeviceIDs_.end());
+
+    for (int i = 0; i <= GLFW_JOYSTICK_LAST; i++) {
         if(glfwJoystickPresent(i)) {
             NumberInputDevices_ ++;
+            InputDeviceIDs_.push_back(i);
         }
     }
 
@@ -42,8 +45,8 @@ void ERS_CLASS_ControllerInputManager::CheckIfSupportedControllers() {
     IsControllerSupported_.erase(IsControllerSupported_.begin(), IsControllerSupported_.end());
 
     // Iterate Through Current Number Controllers
-    for (int i = 0; i < NumberInputDevices_; i++) {
-        IsControllerSupported_.push_back(glfwJoystickIsGamepad(i));
+    for (unsigned int i = 0; i < InputDeviceIDs_.size(); i++) {
+        IsControllerSupported_.push_back(glfwJoystickIsGamepad(InputDeviceIDs_[i]));
     }
 
 }
@@ -53,23 +56,29 @@ void ERS_CLASS_ControllerInputManager::UpdateControllerStates() {
     // Clear States
     ControllerStates_.erase(ControllerStates_.begin(), ControllerStates_.end());
     ControllerNames_.erase(ControllerNames_.begin(), ControllerNames_.end());
+    ControllerSettings_.erase(ControllerSettings_.begin(), ControllerSettings_.end());
     NumberControllers_ = 0;
 
     // Iterate Through Joysticks, Check If Controller
-    for (int i = 0; i < NumberInputDevices_; i++) {
+    for (unsigned int i = 0; i < InputDeviceIDs_.size(); i++) {
 
-        if (IsControllerSupported_[i]) {
-
-            // Incriment Number Of Controller Info
-            NumberControllers_++;
+        if ((i < IsControllerSupported_.size()) && IsControllerSupported_[i]) {
 
             // Get Controller Info
             GLFWgamepadstate State;
-            glfwGetGamepadState(i, &State);
+            if (!glfwGetGamepadState(InputDeviceIDs_[i], &State)) {
+                continue;
+            }
+
+            const char* ControllerName = glfwGetGamepadName(InputDeviceIDs_[i]);
             ControllerStates_.push_back(State);
 
             // Append To Name
-            ControllerNames_.push_back(std::string(glfwGetGamepadName(i)));
+            if (ControllerName == nullptr) {
+                ControllerNames_.push_back("Unknown Controller");
+            } else {
+                ControllerNames_.push_back(std::string(ControllerName));
+            }
 
             // Add Default Settings
             ControllerSettings_.push_back(ERS_STRUCT_ControllerSettings());
@@ -78,19 +87,16 @@ void ERS_CLASS_ControllerInputManager::UpdateControllerStates() {
 
     }
 
+    NumberControllers_ = (int)ControllerStates_.size();
+
 
 }
 
 
 void ERS_CLASS_ControllerInputManager::UpdateControllers() {
 
-    // On First Frame, Detect Controllers
-    if (FirstFrame_) {
-        DetectControllers();
-        FirstFrame_ = false;
-    }
-
     // Update Data
+    DetectControllers();
     UpdateControllerStates();
 
 }

--- a/Source/Core/Manager/ERS_ControllerManager/ControllerInputManager.h
+++ b/Source/Core/Manager/ERS_ControllerManager/ControllerInputManager.h
@@ -30,10 +30,10 @@ class ERS_CLASS_ControllerInputManager {
 private:
 
     ERS_STRUCT_SystemUtils* SystemUtils_;           /**<Pointer to SystemUtils Struct*/
+    std::vector<int>        InputDeviceIDs_;        /**<GLFW joystick IDs for connected input devices*/
     std::vector<bool>       IsControllerSupported_; /**<Indicate If Controller Is Supported Or Not*/
 
-    int NumberInputDevices_ = 0;    /**<Current Number Of "Joysticks" Connected*/
-    bool FirstFrame_        = true; /**<Only True On First Frame*/
+    int NumberInputDevices_ = 0; /**<Current Number Of "Joysticks" Connected*/
 
 
 


### PR DESCRIPTION
## Summary
- Refreshes GLFW joystick/controller detection every frame instead of keeping first-frame device IDs.
- Tracks actual GLFW joystick IDs before reading gamepad state and skips controllers whose state read fails.
- Keeps controller settings UI indexes clamped before reading controller state/profile arrays.

## Notes
- I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `git diff --check`
- `cmake -S . -B Build/ers-79-check -DCMAKE_BUILD_TYPE=Debug` fails during configure in this checkout because `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` is missing and CMake has no `Unix Makefiles` build program configured.

Fixes #79