### PR TITLE
Add scene entity identity helpers

### DIFF
--- a/Source/Core/Structures/ERS_STRUCT_Scene/Scene.cpp
+++ b/Source/Core/Structures/ERS_STRUCT_Scene/Scene.cpp
@@ -5,6 +5,19 @@
 #include <Scene.h>
 
 
+static ERS_STRUCT_SceneObject ERS_FUNCTION_CreateSceneObject(ERS_ENUM_SceneObjectType EntityType, unsigned long Index, const std::string& Label) {
+
+    ERS_STRUCT_SceneObject SceneObject;
+    SceneObject.EntityType_ = EntityType;
+    SceneObject.Type_ = ERS_FUNCTION_GetSceneObjectTypeName(EntityType);
+    SceneObject.Index_ = Index;
+    SceneObject.EntityID_ = ERS_FUNCTION_CreateSceneEntityID(EntityType, Index);
+    SceneObject.Label_ = Label;
+
+    return SceneObject;
+}
+
+
 
 void ERS_STRUCT_Scene::IndexSceneObjects() {
 
@@ -14,44 +27,88 @@ void ERS_STRUCT_Scene::IndexSceneObjects() {
 
     // Add Models
     for (unsigned long i = 0; i < Models.size(); i++) {
-        ERS_STRUCT_SceneObject SceneObject;
-        SceneObject.Type_ = std::string("Model");
-        SceneObject.Index_ = i;
-        SceneObject.Label_ = std::string("[M] ") + Models[i]->Name;
-        SceneObjects_.push_back(SceneObject);
+        SceneObjects_.push_back(ERS_FUNCTION_CreateSceneObject(ERS_ENUM_SceneObjectType::Model, i, std::string("[M] ") + Models[i]->Name));
     }
     
     // Add Lights
     for (unsigned long i = 0; i < SpotLights.size(); i++) {
-        ERS_STRUCT_SceneObject SceneObject;
-        SceneObject.Type_ = std::string("SpotLight");
-        SceneObject.Index_ = i;
-        SceneObject.Label_ = std::string("[LS] ") + SpotLights[i]->UserDefinedName;
-        SceneObjects_.push_back(SceneObject);
+        SceneObjects_.push_back(ERS_FUNCTION_CreateSceneObject(ERS_ENUM_SceneObjectType::SpotLight, i, std::string("[LS] ") + SpotLights[i]->UserDefinedName));
     }
     for (unsigned long i = 0; i < DirectionalLights.size(); i++) {
-        ERS_STRUCT_SceneObject SceneObject;
-        SceneObject.Type_ = std::string("DirectionalLight");
-        SceneObject.Index_ = i;
-        SceneObject.Label_ = std::string("[LD] ") + DirectionalLights[i]->UserDefinedName;
-        SceneObjects_.push_back(SceneObject);
+        SceneObjects_.push_back(ERS_FUNCTION_CreateSceneObject(ERS_ENUM_SceneObjectType::DirectionalLight, i, std::string("[LD] ") + DirectionalLights[i]->UserDefinedName));
     }
     for (unsigned long i = 0; i < PointLights.size(); i++) {
-        ERS_STRUCT_SceneObject SceneObject;
-        SceneObject.Type_ = std::string("PointLight");
-        SceneObject.Index_ = i;
-        SceneObject.Label_ = std::string("[LP] ") + PointLights[i]->UserDefinedName;
-        SceneObjects_.push_back(SceneObject);
+        SceneObjects_.push_back(ERS_FUNCTION_CreateSceneObject(ERS_ENUM_SceneObjectType::PointLight, i, std::string("[LP] ") + PointLights[i]->UserDefinedName));
     }
 
     // Add Scene Cameras
     for (unsigned long i = 0; i < SceneCameras.size(); i++) {
-        ERS_STRUCT_SceneObject SceneObject;
-        SceneObject.Type_ = std::string("SceneCamera");
-        SceneObject.Index_ = i;
-        SceneObject.Label_ = std::string("[C] ") + SceneCameras[i]->UserDefinedName_;
-        SceneObjects_.push_back(SceneObject);
+        SceneObjects_.push_back(ERS_FUNCTION_CreateSceneObject(ERS_ENUM_SceneObjectType::SceneCamera, i, std::string("[C] ") + SceneCameras[i]->UserDefinedName_));
     }
     
 
+}
+
+
+ERS_STRUCT_SceneObject* ERS_STRUCT_Scene::GetSceneObject(unsigned long SceneObjectIndex) {
+
+    if (SceneObjectIndex >= SceneObjects_.size()) {
+        return nullptr;
+    }
+
+    return &SceneObjects_[SceneObjectIndex];
+}
+
+
+const ERS_STRUCT_SceneObject* ERS_STRUCT_Scene::GetSceneObject(unsigned long SceneObjectIndex) const {
+
+    if (SceneObjectIndex >= SceneObjects_.size()) {
+        return nullptr;
+    }
+
+    return &SceneObjects_[SceneObjectIndex];
+}
+
+
+ERS_STRUCT_SceneObject* ERS_STRUCT_Scene::GetSelectedSceneObject() {
+
+    if (SelectedObject < 0) {
+        return nullptr;
+    }
+
+    return GetSceneObject(static_cast<unsigned long>(SelectedObject));
+}
+
+
+const ERS_STRUCT_SceneObject* ERS_STRUCT_Scene::GetSelectedSceneObject() const {
+
+    if (SelectedObject < 0) {
+        return nullptr;
+    }
+
+    return GetSceneObject(static_cast<unsigned long>(SelectedObject));
+}
+
+
+ERS_STRUCT_SceneObject* ERS_STRUCT_Scene::FindSceneObjectByEntityID(std::uint64_t EntityID) {
+
+    for (unsigned long i = 0; i < SceneObjects_.size(); i++) {
+        if (SceneObjects_[i].EntityID_ == EntityID) {
+            return &SceneObjects_[i];
+        }
+    }
+
+    return nullptr;
+}
+
+
+const ERS_STRUCT_SceneObject* ERS_STRUCT_Scene::FindSceneObjectByEntityID(std::uint64_t EntityID) const {
+
+    for (unsigned long i = 0; i < SceneObjects_.size(); i++) {
+        if (SceneObjects_[i].EntityID_ == EntityID) {
+            return &SceneObjects_[i];
+        }
+    }
+
+    return nullptr;
 }

--- a/Source/Core/Structures/ERS_STRUCT_Scene/Scene.h
+++ b/Source/Core/Structures/ERS_STRUCT_Scene/Scene.h
@@ -5,6 +5,7 @@
 #pragma once
 
 // Standard Libraries (BG convention: use <> instead of "")
+#include <cstdint>
 #include <string>
 
 // Third-Party Libraries (BG convention: use <> instead of "")
@@ -59,6 +60,35 @@ struct ERS_STRUCT_Scene{
      * 
      */
     void IndexSceneObjects(); 
+
+
+    /**
+     * @brief Gets A Scene Object By SceneObjects_ Index.
+     *
+     * @param SceneObjectIndex
+     * @return ERS_STRUCT_SceneObject*
+     */
+    ERS_STRUCT_SceneObject* GetSceneObject(unsigned long SceneObjectIndex);
+    const ERS_STRUCT_SceneObject* GetSceneObject(unsigned long SceneObjectIndex) const;
+
+
+    /**
+     * @brief Gets The Currently Selected Scene Object.
+     *
+     * @return ERS_STRUCT_SceneObject*
+     */
+    ERS_STRUCT_SceneObject* GetSelectedSceneObject();
+    const ERS_STRUCT_SceneObject* GetSelectedSceneObject() const;
+
+
+    /**
+     * @brief Finds A Scene Object By Runtime Entity ID.
+     *
+     * @param EntityID
+     * @return ERS_STRUCT_SceneObject*
+     */
+    ERS_STRUCT_SceneObject* FindSceneObjectByEntityID(std::uint64_t EntityID);
+    const ERS_STRUCT_SceneObject* FindSceneObjectByEntityID(std::uint64_t EntityID) const;
 
 
 };

--- a/Source/Core/Structures/ERS_STRUCT_SceneObject/SceneObject.cpp
+++ b/Source/Core/Structures/ERS_STRUCT_SceneObject/SceneObject.cpp
@@ -2,6 +2,7 @@
 // This file is part of the BrainGenix-ERS Environment Rendering System //
 //======================================================================//
 
+// cppcheck-suppress missingIncludeSystem
 #include <SceneObject.h>
 
 

--- a/Source/Core/Structures/ERS_STRUCT_SceneObject/SceneObject.cpp
+++ b/Source/Core/Structures/ERS_STRUCT_SceneObject/SceneObject.cpp
@@ -3,3 +3,66 @@
 //======================================================================//
 
 #include <SceneObject.h>
+
+
+std::string ERS_FUNCTION_GetSceneObjectTypeName(ERS_ENUM_SceneObjectType Type) {
+
+    switch (Type) {
+        case ERS_ENUM_SceneObjectType::Model:
+            return std::string("Model");
+
+        case ERS_ENUM_SceneObjectType::SpotLight:
+            return std::string("SpotLight");
+
+        case ERS_ENUM_SceneObjectType::DirectionalLight:
+            return std::string("DirectionalLight");
+
+        case ERS_ENUM_SceneObjectType::PointLight:
+            return std::string("PointLight");
+
+        case ERS_ENUM_SceneObjectType::SceneCamera:
+            return std::string("SceneCamera");
+
+        case ERS_ENUM_SceneObjectType::Unknown:
+        default:
+            return std::string("Unknown");
+    }
+}
+
+
+ERS_ENUM_SceneObjectType ERS_FUNCTION_GetSceneObjectTypeFromName(const std::string& Type) {
+
+    if (Type == std::string("Model")) {
+        return ERS_ENUM_SceneObjectType::Model;
+    }
+
+    if (Type == std::string("SpotLight")) {
+        return ERS_ENUM_SceneObjectType::SpotLight;
+    }
+
+    if (Type == std::string("DirectionalLight")) {
+        return ERS_ENUM_SceneObjectType::DirectionalLight;
+    }
+
+    if (Type == std::string("PointLight")) {
+        return ERS_ENUM_SceneObjectType::PointLight;
+    }
+
+    if (Type == std::string("SceneCamera")) {
+        return ERS_ENUM_SceneObjectType::SceneCamera;
+    }
+
+    return ERS_ENUM_SceneObjectType::Unknown;
+}
+
+
+std::uint64_t ERS_FUNCTION_CreateSceneEntityID(ERS_ENUM_SceneObjectType Type, unsigned long Index) {
+
+    constexpr std::uint64_t TypeBitShift = 32;
+    constexpr std::uint64_t IndexMask = 0xFFFFFFFFULL;
+
+    std::uint64_t TypeID = static_cast<std::uint64_t>(Type);
+    std::uint64_t ObjectIndex = static_cast<std::uint64_t>(Index);
+
+    return (TypeID << TypeBitShift) | (ObjectIndex & IndexMask);
+}

--- a/Source/Core/Structures/ERS_STRUCT_SceneObject/SceneObject.h
+++ b/Source/Core/Structures/ERS_STRUCT_SceneObject/SceneObject.h
@@ -8,6 +8,7 @@
 #pragma once
 
 // Standard Libraries (BG convention: use <> instead of "")
+#include <cstdint>
 #include <string>
 
 // Third-Party Libraries (BG convention: use <> instead of "")
@@ -17,13 +18,34 @@
 
 
 /**
+ * @brief Runtime object kinds used by scene entities.
+ *
+ */
+enum class ERS_ENUM_SceneObjectType : std::uint8_t {
+    Unknown = 0,
+    Model,
+    SpotLight,
+    DirectionalLight,
+    PointLight,
+    SceneCamera
+};
+
+
+std::string ERS_FUNCTION_GetSceneObjectTypeName(ERS_ENUM_SceneObjectType Type);
+ERS_ENUM_SceneObjectType ERS_FUNCTION_GetSceneObjectTypeFromName(const std::string& Type);
+std::uint64_t ERS_FUNCTION_CreateSceneEntityID(ERS_ENUM_SceneObjectType Type, unsigned long Index);
+
+
+/**
  * @brief Struct containing the info about an object in the scene
  * 
  */
 struct ERS_STRUCT_SceneObject {
 
+    std::uint64_t EntityID_ = 0; /**<Runtime Entity ID Generated From The Object Type And Index*/
+    ERS_ENUM_SceneObjectType EntityType_ = ERS_ENUM_SceneObjectType::Unknown; /**<Runtime Entity Type*/
     std::string Type_; /**<Name Of The Type Of The Object*/
     std::string Label_; /**<Human Readable Name Of The Object*/
-    unsigned long Index_; /**<Index in respective list (e.g. If Type Is Model, This Would Be The Index In The Model List)*/
+    unsigned long Index_ = 0; /**<Index in respective list (e.g. If Type Is Model, This Would Be The Index In The Model List)*/
 
 };


### PR DESCRIPTION
Fixes #92.

This adds a first-pass runtime entity identity layer over the existing scene-object index without changing the editor, renderer, loaders, or scene serialization.

Included in this patch:

- adds an enum-backed scene-object type while preserving the existing string `Type_` values used by current UI and renderer code
- adds deterministic runtime `EntityID_` values generated from scene-object type and per-type index during `IndexSceneObjects()`
- adds helpers to convert scene-object type names, create entity IDs, get the selected scene object safely, and find scene objects by entity ID
- keeps the implementation scoped to `Scene` and `SceneObject` structures so it does not overlap the current editor/renderer/loader PRs

Intentionally not included yet:

- a full ECS/component runtime
- persistent entity IDs in scene YAML
- loader/writer/editor/renderer/script binding migrations

Verification:

- `git diff --check` passed
- `clang++ -std=c++20 -fsyntax-only -ISource/Core/Structures/ERS_STRUCT_SceneObject Source/Core/Structures/ERS_STRUCT_SceneObject/SceneObject.cpp` passed
- compiled and ran a focused helper test for type-name conversion and entity-ID uniqueness
- local `cmake -S . -B Build/ers-92-check` is blocked because this checkout is missing `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` and CMake has no `Unix Makefiles` build program configured

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.