### PR TITLE
Add editor layout preset menu

### DIFF
--- a/EditorAssets/Configuration/Layouts/Default.yaml
+++ b/EditorAssets/Configuration/Layouts/Default.yaml
@@ -3,4 +3,5 @@
 # All other window info is stored in the associated .ini file.                                            #
 ###########################################################################################################
 
-
+DisplayName: Default
+ImGuiIniPath: ../../DefaultLayout/imgui.ini

--- a/Source/Core/Editor/CMakeLists.txt
+++ b/Source/Core/Editor/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries(VisualEditor
     ERS_Editor_ThemeManager
     ERS_Editor_FontManager
     ERS_Editor_UserProfileManager
+    ERS_Editor_LayoutManager
     ERS_Editor_3DCursor
     ERS_Editor_WindowManager
 
@@ -43,6 +44,7 @@ target_link_libraries(VisualEditor
 
     Menu_File
     Menu_Window
+    Menu_Layout
     Menu_Debug
     Menu_Settings
 

--- a/Source/Core/Editor/GUI.cpp
+++ b/Source/Core/Editor/GUI.cpp
@@ -28,6 +28,7 @@ GUISystem::GUISystem(ERS_STRUCT_SystemUtils* SystemUtils, GLFWwindow* Window, Cu
     ThemeManager_ = std::make_unique<ERS_CLASS_ThemeManager>(SystemUtils_->Logger_.get());
     FontManager_ = std::make_unique<ERS_CLASS_FontManager>(SystemUtils_->Logger_.get());
     UserProfileManager_ = std::make_unique<ERS_CLASS_UserProfileManager>(SystemUtils_->Logger_.get());
+    LayoutManager_ = std::make_unique<ERS_CLASS_LayoutManager>(SystemUtils_->Logger_.get());
 
     // Load User Profile
     ThemeManager_->ApplyThemes(UserProfileManager_->GetUserColorProfile().c_str());
@@ -47,6 +48,7 @@ GUISystem::GUISystem(ERS_STRUCT_SystemUtils* SystemUtils, GLFWwindow* Window, Cu
     SystemUtils_->Logger_->Log("Initializing Editor Menus", 5);
     Menu_File_ = std::make_unique<GUI_Menu_File>(SystemUtils_, SceneManager_, ProjectUtils_, WindowManager_->GetWindowsStruct());
     Menu_Window_ = std::make_unique<GUI_Menu_Window>(SystemUtils_, WindowManager_->GetWindowsStruct(), VisualRenderer_);
+    Menu_Layout_ = std::make_unique<GUI_Menu_Layout>(SystemUtils_, LayoutManager_.get());
     Menu_Debug_ = std::make_unique<GUI_Menu_Debug>(SystemUtils_, WindowManager_->GetWindowsStruct(), WindowManager_.get());
     Menu_Settings_ = std::make_unique<GUI_Menu_Settings>(SystemUtils_, HIDUtils_, WindowManager_->GetWindowsStruct());
 
@@ -100,6 +102,7 @@ void GUISystem::UpdateGUI() {
 
         Menu_File_->Draw();
         Menu_Window_->Draw();
+        Menu_Layout_->Draw();
         Menu_Settings_->Draw();
         Menu_Debug_->Draw();
 

--- a/Source/Core/Editor/GUI.h
+++ b/Source/Core/Editor/GUI.h
@@ -30,6 +30,7 @@
 #include <ThemeManager.h>
 #include <FontManager.h>
 #include <UserProfileManager.h>
+#include <LayoutManager.h>
 #include <3DCursor.h>
 #include <WindowManager.h>
 
@@ -37,6 +38,7 @@
 
 #include <GUI_Menu_File.h>
 #include <GUI_Menu_Window.h>
+#include <GUI_Menu_Layout.h>
 #include <GUI_Menu_Debug.h>
 #include <GUI_Menu_Settings.h>
 
@@ -63,6 +65,7 @@ private:
 
     std::unique_ptr<ERS_CLASS_FontManager>        FontManager_;        /**<Pointer To FontManager Instance*/
     std::unique_ptr<ERS_CLASS_UserProfileManager> UserProfileManager_; /**<Pointer To User Profile Manager Instance*/
+    std::unique_ptr<ERS_CLASS_LayoutManager>      LayoutManager_;      /**<Pointer To Layout Manager Instance*/
     std::unique_ptr<ERS_CLASS_WindowManager>      WindowManager_;      /**<Class owning all gui windows*/
     
 public:
@@ -72,6 +75,7 @@ public:
     // Menu Items
     std::unique_ptr<GUI_Menu_File>     Menu_File_;     /**<Editor Menu Entry*/
     std::unique_ptr<GUI_Menu_Window>   Menu_Window_;   /**<Editor Menu Entry*/
+    std::unique_ptr<GUI_Menu_Layout>   Menu_Layout_;   /**<Editor Menu Entry*/
     std::unique_ptr<GUI_Menu_Debug>    Menu_Debug_;    /**<Editor Menu Entry*/
     std::unique_ptr<GUI_Menu_Settings> Menu_Settings_; /**<Editor Menu Entry*/
 

--- a/Source/Core/Editor/Menus/CMakeLists.txt
+++ b/Source/Core/Editor/Menus/CMakeLists.txt
@@ -5,5 +5,6 @@
 # Add Menu Entries
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/GUI_Menu_File)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/GUI_Menu_Window)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/GUI_Menu_Layout)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/GUI_Menu_Debug)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/GUI_Menu_Settings)

--- a/Source/Core/Editor/Menus/GUI_Menu_Layout/CMakeLists.txt
+++ b/Source/Core/Editor/Menus/GUI_Menu_Layout/CMakeLists.txt
@@ -1,0 +1,23 @@
+########################################################################
+# This file is part of the BrainGenix-ERS Environment Rendering System #
+########################################################################
+
+
+add_library(Menu_Layout
+            "GUI_Menu_Layout.cpp"
+            "GUI_Menu_Layout.h"
+            ${BACKWARD_ENABLE}
+            )
+set_property(TARGET Menu_Layout PROPERTY CXX_STANDARD 17)
+
+target_link_libraries(Menu_Layout
+    IMGUI
+    )
+
+target_link_libraries(Menu_Layout
+    bg-common-logger
+    ERS_STRUCT_SystemUtils
+    ERS_Editor_LayoutManager
+    )
+
+target_include_directories(Menu_Layout PUBLIC ./)

--- a/Source/Core/Editor/Menus/GUI_Menu_Layout/GUI_Menu_Layout.cpp
+++ b/Source/Core/Editor/Menus/GUI_Menu_Layout/GUI_Menu_Layout.cpp
@@ -2,6 +2,7 @@
 // This file is part of the BrainGenix-ERS Environment Rendering System //
 //======================================================================//
 
+// cppcheck-suppress missingIncludeSystem
 #include <GUI_Menu_Layout.h>
 
 

--- a/Source/Core/Editor/Menus/GUI_Menu_Layout/GUI_Menu_Layout.cpp
+++ b/Source/Core/Editor/Menus/GUI_Menu_Layout/GUI_Menu_Layout.cpp
@@ -1,0 +1,93 @@
+//======================================================================//
+// This file is part of the BrainGenix-ERS Environment Rendering System //
+//======================================================================//
+
+#include <GUI_Menu_Layout.h>
+
+
+GUI_Menu_Layout::GUI_Menu_Layout(ERS_STRUCT_SystemUtils* SystemUtils, ERS_CLASS_LayoutManager* LayoutManager) {
+
+    SystemUtils_ = SystemUtils;
+    LayoutManager_ = LayoutManager;
+    SystemUtils_->Logger_->Log("Editor Setting Up Layout Menu", 4);
+
+}
+
+
+GUI_Menu_Layout::~GUI_Menu_Layout() {
+
+    SystemUtils_->Logger_->Log("Editor Destroying Layout Menu", 4);
+
+}
+
+
+void GUI_Menu_Layout::EnsureLayoutsLoaded() {
+
+    if (!LayoutsLoaded_) {
+        LayoutManager_->LoadLayouts();
+        LayoutsLoaded_ = true;
+    }
+}
+
+
+void GUI_Menu_Layout::DrawSaveLayoutPopup() {
+
+    if (ImGui::BeginPopupModal("Save Layout Preset", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+        ImGui::InputTextWithHint("Layout Name", "Preset Name", LayoutNameBuffer_, IM_ARRAYSIZE(LayoutNameBuffer_));
+
+        if (ImGui::Button("Save", ImVec2(120, 0)) || ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_Enter))) {
+            LayoutManager_->CreateLayout(LayoutNameBuffer_);
+            LayoutsLoaded_ = true;
+            ImGui::CloseCurrentPopup();
+        }
+
+        ImGui::SameLine();
+
+        if (ImGui::Button("Cancel", ImVec2(120, 0)) || ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_Escape))) {
+            ImGui::CloseCurrentPopup();
+        }
+
+    ImGui::EndPopup();
+    }
+}
+
+
+void GUI_Menu_Layout::Draw() {
+
+    EnsureLayoutsLoaded();
+
+    if (ImGui::BeginMenu("Layout")) {
+
+        if (ImGui::BeginMenu("Apply Preset")) {
+            std::vector<std::string> LayoutNames = LayoutManager_->GetLayoutNames();
+            std::string ActiveLayoutName = LayoutManager_->GetActiveLayoutName();
+
+            if (LayoutNames.size() == 0) {
+                ImGui::MenuItem("No Layouts Found", "", false, false);
+            }
+
+            for (unsigned long i = 0; i < LayoutNames.size(); i++) {
+                bool Selected = LayoutNames[i] == ActiveLayoutName;
+                if (ImGui::MenuItem(LayoutNames[i].c_str(), "", Selected)) {
+                    LayoutManager_->ApplyLayout((int)i);
+                }
+            }
+
+        ImGui::EndMenu();
+        }
+
+        if (ImGui::MenuItem("Save Current Layout...")) {
+            ImGui::OpenPopup("Save Layout Preset");
+        }
+
+        if (ImGui::MenuItem("Reload Layouts")) {
+            LayoutManager_->LoadLayouts();
+            LayoutsLoaded_ = true;
+        }
+
+    ImGui::EndMenu();
+    }
+
+    DrawSaveLayoutPopup();
+
+}

--- a/Source/Core/Editor/Menus/GUI_Menu_Layout/GUI_Menu_Layout.h
+++ b/Source/Core/Editor/Menus/GUI_Menu_Layout/GUI_Menu_Layout.h
@@ -1,0 +1,58 @@
+//======================================================================//
+// This file is part of the BrainGenix-ERS Environment Rendering System //
+//======================================================================//
+
+#pragma once
+
+// Standard Libraries (BG convention: use <> instead of "")
+#include <string>
+#include <vector>
+
+// Third-Party Libraries (BG convention: use <> instead of "")
+#include <imgui.h>
+
+// Internal Libraries (BG convention: use <> instead of "")
+#include <SystemUtils.h>
+#include <LayoutManager.h>
+
+
+/**
+ * @brief This class provides the "Layout" Menu In The Editor.
+ *
+ */
+class GUI_Menu_Layout {
+
+private:
+
+    ERS_STRUCT_SystemUtils* SystemUtils_ = nullptr; /**<SystemUtils Instance, Used To Get Systems From Other Classes*/
+    ERS_CLASS_LayoutManager* LayoutManager_ = nullptr; /**<Layout Manager Instance*/
+
+    bool LayoutsLoaded_ = false; /**<Tracks if layouts have been indexed during this editor session*/
+    char LayoutNameBuffer_[128] = "New Layout"; /**<Input buffer used when saving a layout preset*/
+
+    void EnsureLayoutsLoaded();
+    void DrawSaveLayoutPopup();
+
+public:
+
+    /**
+     * @brief Construct a new gui menu layout object
+     *
+     * @param SystemUtils
+     * @param LayoutManager
+     */
+    GUI_Menu_Layout(ERS_STRUCT_SystemUtils* SystemUtils, ERS_CLASS_LayoutManager* LayoutManager);
+
+    /**
+     * @brief Destroy the gui menu layout object
+     *
+     */
+    ~GUI_Menu_Layout();
+
+    /**
+     * @brief This function Draws The Layout Menu Contents.
+     *
+     */
+    void Draw();
+
+};

--- a/Source/Core/Editor/Utils/ERS_Editor_LayoutManager/LayoutManager.cpp
+++ b/Source/Core/Editor/Utils/ERS_Editor_LayoutManager/LayoutManager.cpp
@@ -4,6 +4,7 @@
 
 #include <LayoutManager.h>
 
+#include <sstream>
 
 
 ERS_CLASS_LayoutManager::ERS_CLASS_LayoutManager(BG::Common::Logger::LoggingSystem* Logger, const char* LayoutDirectory) {
@@ -21,32 +22,121 @@ ERS_CLASS_LayoutManager::~ERS_CLASS_LayoutManager() {
 
 }
 
+static std::string ERS_FUNCTION_SanitizeLayoutFileStem(std::string LayoutName) {
+
+    if (LayoutName.empty()) {
+        return std::string("Layout");
+    }
+
+    for (unsigned long i = 0; i < LayoutName.size(); i++) {
+        char Character = LayoutName[i];
+        bool IsAlphaNumeric = ((Character >= 'a') && (Character <= 'z')) || ((Character >= 'A') && (Character <= 'Z')) || ((Character >= '0') && (Character <= '9'));
+
+        if (!IsAlphaNumeric && (Character != '-') && (Character != '_')) {
+            LayoutName[i] = '_';
+        }
+    }
+
+    return LayoutName;
+}
+
+static bool ERS_FUNCTION_ReadLayoutIniFile(const ghc::filesystem::path& FilePath, std::string* Output) {
+
+    std::ifstream InputFile(FilePath.u8string(), std::ios::binary);
+    if (!InputFile.is_open()) {
+        return false;
+    }
+
+    std::ostringstream Buffer;
+    Buffer << InputFile.rdbuf();
+    *Output = Buffer.str();
+
+    return true;
+}
+
+static bool ERS_FUNCTION_IsAbsoluteLayoutPath(const std::string& FilePath) {
+
+    if (FilePath.empty()) {
+        return false;
+    }
+
+    if ((FilePath[0] == '/') || (FilePath[0] == '\\')) {
+        return true;
+    }
+
+    return (FilePath.size() > 1) && (FilePath[1] == ':');
+}
+
 void ERS_CLASS_LayoutManager::LoadLayouts() {
 
-    // Create List Of Files
-    for (const auto& Entry : ghc::filesystem::directory_iterator(std::string(LayoutDirectory_))) {
+    LayoutFiles_.clear();
+    LayoutNames_.clear();
+    Layouts_.clear();
+    Index = 0;
+
+    ghc::filesystem::path LayoutDirectoryPath(LayoutDirectory_);
+    if (!ghc::filesystem::exists(LayoutDirectoryPath)) {
+        ghc::filesystem::create_directories(LayoutDirectoryPath);
+    }
+
+    for (const auto& Entry : ghc::filesystem::directory_iterator(LayoutDirectoryPath)) {
+
+        if (!ghc::filesystem::is_regular_file(Entry.path())) {
+            continue;
+        }
+
+        std::string Extension = Entry.path().extension().u8string();
+        if ((Extension != std::string(".yaml")) && (Extension != std::string(".yml"))) {
+            continue;
+        }
 
         // Get File Path
         std::string FilePath{ Entry.path().u8string() };
 
         // Load YAML::Node
-        YAML::Node LayoutNode = YAML::LoadFile(FilePath.c_str());
+        YAML::Node LayoutNode;
+        try {
+            LayoutNode = YAML::LoadFile(FilePath.c_str());
+        } catch (const YAML::Exception& Exception) {
+            Logger_->Log(std::string(std::string("Failed To Load Layout File '") + FilePath + std::string("': ") + Exception.what()).c_str(), 7);
+            continue;
+        }
         
         // Build Temp Layout
         ERS_STRUCT_EditorLayout Layout;
         Layout.index = Index;
 
         // Parse Out Display Name From File
-        std::string LayoutName;
-        LayoutName = LayoutNode["DisplayName"].as<std::string>();
+        std::string LayoutName = Entry.path().stem().u8string();
+        if (LayoutNode["DisplayName"]) {
+            LayoutName = LayoutNode["DisplayName"].as<std::string>();
+        }
         Layout.name = LayoutName;
 
-        // Parse Out Ini String From File
+        // Parse Out Ini String From File Or Referenced Ini Asset
         std::string IniStr;
-        IniStr = LayoutNode["ImGuiIni"].as<std::string>();
+        if (LayoutNode["ImGuiIni"]) {
+            IniStr = LayoutNode["ImGuiIni"].as<std::string>();
+        } else if (LayoutNode["ImGuiIniPath"]) {
+            std::string IniPathString = LayoutNode["ImGuiIniPath"].as<std::string>();
+            ghc::filesystem::path IniPath(IniPathString);
+            if (!ERS_FUNCTION_IsAbsoluteLayoutPath(IniPathString)) {
+                IniPath = LayoutDirectoryPath / IniPath;
+            }
+
+            if (!ERS_FUNCTION_ReadLayoutIniFile(IniPath, &IniStr)) {
+                Logger_->Log(std::string(std::string("Failed To Read Layout Ini File '") + IniPath.u8string() + std::string("'")).c_str(), 7);
+                continue;
+            }
+        } else {
+            Logger_->Log(std::string(std::string("Skipping Layout Without ImGuiIni Data: ") + FilePath).c_str(), 5);
+            continue;
+        }
+
         Layout.IniString = IniStr;
 
         // Add To Names and Layouts Vector
+        LayoutFiles_.push_back(LayoutNode);
         LayoutNames_.push_back(LayoutName);
         Layouts_.push_back(Layout);
 
@@ -63,20 +153,43 @@ void ERS_CLASS_LayoutManager::LoadLayouts() {
 
 void ERS_CLASS_LayoutManager::SaveLayout(std::string LayoutName) {
 
+    if (LayoutName.empty()) {
+        LayoutName = std::string("Layout");
+    }
+
+    ghc::filesystem::path LayoutDirectoryPath(LayoutDirectory_);
+    if (!ghc::filesystem::exists(LayoutDirectoryPath)) {
+        ghc::filesystem::create_directories(LayoutDirectoryPath);
+    }
+
     // Save the Ini String
     std::string IniStr;
     size_t settings_size = 0;
-    IniStr = static_cast<std::string> (ImGui::SaveIniSettingsToMemory(&settings_size));
+    const char* Settings = ImGui::SaveIniSettingsToMemory(&settings_size);
+    IniStr = std::string(Settings, settings_size);
 
-    // Add To Names Vector
-    LayoutNames_.push_back(LayoutName);
+    bool ExistingLayoutFound = false;
+    for (unsigned long i = 0; i < LayoutNames_.size(); i++) {
+        if (LayoutNames_[i] == LayoutName) {
+            Layouts_[i].IniString = IniStr;
+            ExistingLayoutFound = true;
+            break;
+        }
+    }
 
-    // Construct the New Layout Struct
-    ERS_STRUCT_EditorLayout newLayout;
-    newLayout.index = Index++;
-    newLayout.name = LayoutName;
-    newLayout.IniString = IniStr;
-    Layouts_.push_back(newLayout);
+    if (!ExistingLayoutFound) {
+        // Add To Names Vector
+        LayoutNames_.push_back(LayoutName);
+
+        // Construct the New Layout Struct
+        ERS_STRUCT_EditorLayout newLayout;
+        newLayout.index = Index++;
+        newLayout.name = LayoutName;
+        newLayout.IniString = IniStr;
+        Layouts_.push_back(newLayout);
+    }
+
+    ActiveLayoutName_ = LayoutName;
 
     // Save YAML Node
     YAML::Node Layout;
@@ -96,7 +209,8 @@ void ERS_CLASS_LayoutManager::SaveLayout(std::string LayoutName) {
     std::string YAMLstring = std::string(LayoutYAML.c_str());
 
     // Write the string into a YAML file in the directory
-    std::ofstream file(std::string(LayoutDirectory_) + "/" + LayoutName + ".yaml");
+    ghc::filesystem::path LayoutPath = LayoutDirectoryPath / (ERS_FUNCTION_SanitizeLayoutFileStem(LayoutName) + std::string(".yaml"));
+    std::ofstream file(LayoutPath.u8string());
 
     if (!file.fail())
         file << YAMLstring;
@@ -127,6 +241,11 @@ void ERS_CLASS_LayoutManager::ApplyLayout(std::string LayoutName) {
 
 void ERS_CLASS_LayoutManager::ApplyLayout(int LayoutID) {
 
+    if ((LayoutID < 0) || (LayoutID >= (int)Layouts_.size())) {
+        Logger_->Log("Failed To Apply Layout, Index Out Of Bounds", 5);
+        return;
+    }
+
     // Get Layout Name
     std::string LayoutName = LayoutNames_[LayoutID];
     ERS_STRUCT_EditorLayout Layout = Layouts_[LayoutID];
@@ -134,5 +253,21 @@ void ERS_CLASS_LayoutManager::ApplyLayout(int LayoutID) {
     Logger_->Log(std::string(std::string("Applying Layout: ") + LayoutName).c_str(), 4);
 
     ImGui::LoadIniSettingsFromMemory(Layout.IniString.c_str());
+    ActiveLayoutName_ = LayoutName;
 
+}
+
+std::string ERS_CLASS_LayoutManager::GetActiveLayoutName() {
+
+    return ActiveLayoutName_;
+}
+
+std::vector<std::string> ERS_CLASS_LayoutManager::GetLayoutNames() {
+
+    return LayoutNames_;
+}
+
+void ERS_CLASS_LayoutManager::CreateLayout(std::string Name) {
+
+    SaveLayout(Name);
 }

--- a/Source/Core/Editor/Utils/ERS_Editor_LayoutManager/LayoutManager.cpp
+++ b/Source/Core/Editor/Utils/ERS_Editor_LayoutManager/LayoutManager.cpp
@@ -4,6 +4,7 @@
 
 #include <LayoutManager.h>
 
+// cppcheck-suppress missingIncludeSystem
 #include <sstream>
 
 

--- a/Source/Core/Editor/Utils/ERS_Editor_LayoutManager/LayoutManager.h
+++ b/Source/Core/Editor/Utils/ERS_Editor_LayoutManager/LayoutManager.h
@@ -8,12 +8,13 @@
 
 // Standard Libraries (BG convention: use <> instead of "")
 #include <string>
-#include <filesystem>
 #include <imgui.h>
 #include <fstream>
 #include <map>
+#include <vector>
 
 // Third-Party Libraries (BG convention: use <> instead of "")
+#include <ghc/filesystem.hpp>
 #include <yaml-cpp/yaml.h>
 
 // Internal Libraries (BG convention: use <> instead of "")
@@ -62,7 +63,7 @@ public:
      * @param WindowManager
      * @param LayoutDirectory
      */
-    ERS_CLASS_LayoutManager(BG::Common::Logger::LoggingSystem* Logger, const char* LayoutDirectory = "EditorAssets/Layouts/");
+    ERS_CLASS_LayoutManager(BG::Common::Logger::LoggingSystem* Logger, const char* LayoutDirectory = "EditorAssets/Configuration/Layouts/");
 
     /**
      * @brief Destroy the Layout Manager object


### PR DESCRIPTION
Fixes #100.

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

This replaces stale/conflicting PR #365 with a fresh branch against current `master`.

Summary:
- Add a top-level `Layout` editor menu with preset apply, reload, and save-current-layout actions.
- Wire the menu through the editor GUI and CMake targets.
- Extend `LayoutManager` to load YAML layout presets from `EditorAssets/Configuration/Layouts`, support external ImGui ini payloads through `ImGuiIniPath`, preserve full ini data on save, and update existing presets by display name.
- Move the default layout payload into `EditorAssets/DefaultLayout/imgui.ini` and point the default preset YAML at it.

Verification:
- `git diff --check`
- Confirmed default layout manifest references `DisplayName` and `ImGuiIniPath`, and that `EditorAssets/DefaultLayout/imgui.ini` exists.
- Focused `clang++ -std=c++17 -fsyntax-only` check for `LayoutManager.cpp` and `GUI_Menu_Layout.cpp` using local stubs for unavailable external dependencies.

Known local build blocker:
- Full CMake configure still cannot run in this checkout because `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` is missing and no Unix Makefiles build program is configured (`CMAKE_MAKE_PROGRAM` unset).
