### PR TITLE
Add controller viewport navigation

### DIFF
--- a/Source/Core/Renderer/ERS_CLASS_RendererManager/RendererManager.cpp
+++ b/Source/Core/Renderer/ERS_CLASS_RendererManager/RendererManager.cpp
@@ -26,7 +26,11 @@ RendererManager::RendererManager(ERS_STRUCT_SystemUtils* SystemUtils, ERS_STRUCT
     InitializeGLFW();
 
     SystemUtils_->Logger_->Log("Instantiating Renderers", 5);
-    VisualRenderer_ = std::make_unique<ERS_CLASS_VisualRenderer>(SystemUtils_, ProjectUtils_, Window_, Cursors3D_.get());
+    ERS_CLASS_ControllerInputManager* ControllerInputManager = nullptr;
+    if (HIDUtils_ != nullptr) {
+        ControllerInputManager = HIDUtils_->ControllerInputManager.get();
+    }
+    VisualRenderer_ = std::make_unique<ERS_CLASS_VisualRenderer>(SystemUtils_, ProjectUtils_, Window_, Cursors3D_.get(), ControllerInputManager);
     LoadEditorData();
     VisualRenderer_->SetOpenGLDefaults(OpenGLDefaults_.get());
 

--- a/Source/Core/Renderer/ERS_CLASS_VisualRenderer/CMakeLists.txt
+++ b/Source/Core/Renderer/ERS_CLASS_VisualRenderer/CMakeLists.txt
@@ -89,8 +89,8 @@ target_link_libraries(ERS_CLASS_VisualRenderer
     ERS_STRUCT_OpenGLDefaults
     ERS_STRUCT_RendererSettings
     ERS_STRUCT_ShaderUniformData
+    ERS_ControllerInputManager
 
     )
 
 target_include_directories(ERS_CLASS_VisualRenderer PUBLIC ./)
-

--- a/Source/Core/Renderer/ERS_CLASS_VisualRenderer/InputProcessor.cpp
+++ b/Source/Core/Renderer/ERS_CLASS_VisualRenderer/InputProcessor.cpp
@@ -4,7 +4,9 @@
 
 #include "InputProcessor.h"
 
+// cppcheck-suppress missingIncludeSystem
 #include <algorithm>
+// cppcheck-suppress missingIncludeSystem
 #include <cmath>
 
 

--- a/Source/Core/Renderer/ERS_CLASS_VisualRenderer/InputProcessor.cpp
+++ b/Source/Core/Renderer/ERS_CLASS_VisualRenderer/InputProcessor.cpp
@@ -4,12 +4,16 @@
 
 #include "InputProcessor.h"
 
+#include <algorithm>
+#include <cmath>
+
 
 // Constructor / Destructor
-ERS_CLASS_InputProcessor::ERS_CLASS_InputProcessor(ERS_STRUCT_Camera* Camera, GLFWwindow *Window) {
+ERS_CLASS_InputProcessor::ERS_CLASS_InputProcessor(ERS_STRUCT_Camera* Camera, GLFWwindow *Window, ERS_CLASS_ControllerInputManager* ControllerInputManager) {
 
     Camera_ = Camera;
     Window_ = Window;
+    ControllerInputManager_ = ControllerInputManager;
     //FramebufferManager_ = FramebufferManager;
 
 }
@@ -34,16 +38,17 @@ void ERS_CLASS_InputProcessor::ProcessMouseScroll(bool CaptureEnabled) {
     }
 
 }
-void ERS_CLASS_InputProcessor::Process(float DeltaTime, bool CaptureEnabled) {
+void ERS_CLASS_InputProcessor::Process(float DeltaTime, bool CaptureEnabled, bool ControllerCaptureEnabled) {
 
     // Update Internal State
-    ProcessKeyboardInput (DeltaTime, CaptureEnabled);
-    UpdateFramebuffer    ();
-    UpdateMouse          (CaptureEnabled);
-    ProcessMouseScroll   (CaptureEnabled);
+    ProcessKeyboardInput   (DeltaTime, CaptureEnabled);
+    ProcessControllerInput (DeltaTime, ControllerCaptureEnabled);
+    UpdateFramebuffer      ();
+    UpdateMouse            (CaptureEnabled);
+    ProcessMouseScroll     (CaptureEnabled);
 
     // Update Associated Camera
-    if (CaptureEnabled || ForceUpdate_) {
+    if (CaptureEnabled || ControllerCaptureEnabled || ForceUpdate_) {
         ForceUpdate_ = false;
         Camera_->SetPosition      (Position_);
         Camera_->SetRotation      (Orientation_);
@@ -51,6 +56,40 @@ void ERS_CLASS_InputProcessor::Process(float DeltaTime, bool CaptureEnabled) {
         Camera_->SetClipBoundries (NearClip_, FarClip_);
         Camera_->Update           ();
     }
+
+}
+bool ERS_CLASS_InputProcessor::HasControllerInput() {
+
+    if (ControllerInputManager_ == nullptr) {
+        return false;
+    }
+
+    for (std::size_t i = 0; i < ControllerInputManager_->ControllerStates_.size(); i++) {
+        GLFWgamepadstate State = ControllerInputManager_->ControllerStates_[i];
+
+        bool HasStickInput =
+            (std::abs(State.axes[GLFW_GAMEPAD_AXIS_LEFT_X]) > ControllerDeadZone_) ||
+            (std::abs(State.axes[GLFW_GAMEPAD_AXIS_LEFT_Y]) > ControllerDeadZone_) ||
+            (std::abs(State.axes[GLFW_GAMEPAD_AXIS_RIGHT_X]) > ControllerDeadZone_) ||
+            (std::abs(State.axes[GLFW_GAMEPAD_AXIS_RIGHT_Y]) > ControllerDeadZone_);
+        bool HasTriggerInput =
+            (NormalizeTrigger(State.axes[GLFW_GAMEPAD_AXIS_LEFT_TRIGGER]) > ControllerDeadZone_) ||
+            (NormalizeTrigger(State.axes[GLFW_GAMEPAD_AXIS_RIGHT_TRIGGER]) > ControllerDeadZone_);
+        bool HasButtonInput =
+            (State.buttons[GLFW_GAMEPAD_BUTTON_LEFT_BUMPER] == GLFW_PRESS) ||
+            (State.buttons[GLFW_GAMEPAD_BUTTON_RIGHT_BUMPER] == GLFW_PRESS);
+
+        if (HasStickInput || HasTriggerInput || HasButtonInput) {
+            return true;
+        }
+    }
+
+    return false;
+
+}
+void ERS_CLASS_InputProcessor::SetControllerInputManager(ERS_CLASS_ControllerInputManager* ControllerInputManager) {
+
+    ControllerInputManager_ = ControllerInputManager;
 
 }
 void ERS_CLASS_InputProcessor::UpdateFramebuffer() {
@@ -81,6 +120,66 @@ void ERS_CLASS_InputProcessor::UpdateMouse( bool WindowMouseCaptureEnabled) {
     }
 
 }
+void ERS_CLASS_InputProcessor::ProcessControllerInput(float DeltaTime, bool ControllerCaptureEnabled) {
+
+    if (!ControllerCaptureEnabled || ControllerInputManager_ == nullptr) {
+        return;
+    }
+
+    for (std::size_t i = 0; i < ControllerInputManager_->ControllerStates_.size(); i++) {
+        GLFWgamepadstate State = ControllerInputManager_->ControllerStates_[i];
+
+        float LeftX = ApplyControllerDeadZone(State.axes[GLFW_GAMEPAD_AXIS_LEFT_X]);
+        float LeftY = ApplyControllerDeadZone(State.axes[GLFW_GAMEPAD_AXIS_LEFT_Y]);
+        float RightX = ApplyControllerDeadZone(State.axes[GLFW_GAMEPAD_AXIS_RIGHT_X]);
+        float RightY = ApplyControllerDeadZone(State.axes[GLFW_GAMEPAD_AXIS_RIGHT_Y]);
+        float LeftTrigger = ApplyControllerDeadZone(NormalizeTrigger(State.axes[GLFW_GAMEPAD_AXIS_LEFT_TRIGGER]));
+        float RightTrigger = ApplyControllerDeadZone(NormalizeTrigger(State.axes[GLFW_GAMEPAD_AXIS_RIGHT_TRIGGER]));
+
+        if (LeftY < 0.0f) {
+            ProcessKey(FORWARD, DeltaTime, std::abs(LeftY));
+        } else if (LeftY > 0.0f) {
+            ProcessKey(BACKWARD, DeltaTime, LeftY);
+        }
+
+        if (LeftX < 0.0f) {
+            ProcessKey(LEFT, DeltaTime, std::abs(LeftX));
+        } else if (LeftX > 0.0f) {
+            ProcessKey(RIGHT, DeltaTime, LeftX);
+        }
+
+        if (State.buttons[GLFW_GAMEPAD_BUTTON_RIGHT_BUMPER] == GLFW_PRESS) {
+            RightTrigger = 1.0f;
+        }
+        if (State.buttons[GLFW_GAMEPAD_BUTTON_LEFT_BUMPER] == GLFW_PRESS) {
+            LeftTrigger = 1.0f;
+        }
+
+        if (RightTrigger > 0.0f) {
+            ProcessKey(UP, DeltaTime, RightTrigger);
+        }
+        if (LeftTrigger > 0.0f) {
+            ProcessKey(DOWN, DeltaTime, LeftTrigger);
+        }
+
+        Orientation_.y += RightX * ControllerLookSensitivity_ * DeltaTime;
+        Orientation_.p += RightY * ControllerLookSensitivity_ * DeltaTime;
+
+        if (ConstrainPitch_) {
+            if (Orientation_.p > 89.0f) {
+                Orientation_.p = 89.0f;
+            }
+            if (Orientation_.p < -89.0f) {
+                Orientation_.p = -89.0f;
+            }
+        }
+
+        if ((LeftX != 0.0f) || (LeftY != 0.0f) || (RightX != 0.0f) || (RightY != 0.0f) || (LeftTrigger != 0.0f) || (RightTrigger != 0.0f)) {
+            break;
+        }
+    }
+
+}
 void ERS_CLASS_InputProcessor::ProcessKeyboardInput(float DeltaTime, bool WindowCaptureEnabled) {
 
 
@@ -103,7 +202,7 @@ void ERS_CLASS_InputProcessor::ProcessKeyboardInput(float DeltaTime, bool Window
     }
 
 }
-void ERS_CLASS_InputProcessor::ProcessKey(CameraMovement Direction, float DeltaTime) {
+void ERS_CLASS_InputProcessor::ProcessKey(CameraMovement Direction, float DeltaTime, float Amount) {
 
     // Calculate Movement Direction Vectors
     glm::mat4 Perspective, ViewMatrix;
@@ -114,7 +213,7 @@ void ERS_CLASS_InputProcessor::ProcessKey(CameraMovement Direction, float DeltaT
     Front  = -glm::normalize(glm::vec3(ViewMatrix[0][2], ViewMatrix[1][2], ViewMatrix[2][2]));
 
     // Calculate Velocity
-    float Velocity = MovementSpeed_ * DeltaTime;
+    float Velocity = MovementSpeed_ * DeltaTime * Amount;
 
     // Update Position(s)
     if (Direction == FORWARD)
@@ -129,6 +228,23 @@ void ERS_CLASS_InputProcessor::ProcessKey(CameraMovement Direction, float DeltaT
         Position_ += Up     * Velocity;
     if (Direction == DOWN)
         Position_ -= Up     * Velocity;
+
+}
+float ERS_CLASS_InputProcessor::ApplyControllerDeadZone(float Value) {
+
+    float Magnitude = std::abs(Value);
+    if (Magnitude <= ControllerDeadZone_) {
+        return 0.0f;
+    }
+
+    float Scaled = (Magnitude - ControllerDeadZone_) / (1.0f - ControllerDeadZone_);
+    return (Value < 0.0f) ? -Scaled : Scaled;
+
+}
+float ERS_CLASS_InputProcessor::NormalizeTrigger(float Value) {
+
+    float Normalized = (Value + 1.0f) * 0.5f;
+    return std::max(0.0f, std::min(1.0f, Normalized));
 
 }
 void ERS_CLASS_InputProcessor::FramebufferSizeCallback(int Width, int Height) {

--- a/Source/Core/Renderer/ERS_CLASS_VisualRenderer/InputProcessor.h
+++ b/Source/Core/Renderer/ERS_CLASS_VisualRenderer/InputProcessor.h
@@ -4,6 +4,9 @@
 
 #pragma once
 
+// Standard Libraries (BG convention: use <> instead of "")
+#include <cstddef>
+
 // Third-Party Libraries (BG convention: use <> instead of "")
 #include <glad/glad.h>
 
@@ -17,6 +20,7 @@
 #include <BG/Common/Logger/Logger.h>
 
 #include <Camera.h>
+#include <ControllerInputManager.h>
 
 
 /**
@@ -38,6 +42,8 @@ private:
     
     float MovementSpeed_     = 0.2f;   /**<Current Movement Speed            */
     float MouseSensitivity_  = 0.05f;  /**<Mouse sensitivity multiplier      */
+    float ControllerLookSensitivity_ = 80.0f; /**<Controller look sensitivity in degrees per second*/
+    float ControllerDeadZone_ = 0.18f;        /**<Minimum controller axis magnitude used by viewport controls*/
     bool  ConstrainPitch_    = true;   /**<Limit the camera to +- 89 degrees */
 
     float NearClip_          = 0.01f;  /**<Closest distance before geometry is culled.*/
@@ -50,11 +56,12 @@ private:
 
     ERS_STRUCT_Camera* Camera_; /**<Pointer To EditorCamera Instance */
     GLFWwindow*        Window_; /**<Pointer To Window Surface        */
+    ERS_CLASS_ControllerInputManager* ControllerInputManager_ = nullptr; /**<Controller state provider*/
 
 
     /**
      * @brief Callback for the framebuffer size (window resize events)
-     * 
+     *
      * @param Width 
      * @param Height 
      */
@@ -62,7 +69,7 @@ private:
 
     /**
      * @brief Callback for mouse position (X,Y)
-     * 
+     *
      * @param XPos 
      * @param YPos 
      */
@@ -106,12 +113,37 @@ private:
     void ProcessKeyboardInput(float DeltaTime, bool WindowCaptureEnabled);
 
     /**
+     * @brief Processes controller input for the editor camera.
+     *
+     * @param DeltaTime Frame time used to ensure speed isn't tied to framerate
+     * @param ControllerCaptureEnabled
+     */
+    void ProcessControllerInput(float DeltaTime, bool ControllerCaptureEnabled);
+
+    /**
      * @brief Processes key input for the editor camera.
-     * 
+     *
      * @param Direction Direction currently being pressed.
      * @param DeltaTime Frame time used to ensure speed isn't tied to framerate
+     * @param Amount Analog input amount from 0.0 to 1.0
      */
-    void ProcessKey(CameraMovement Direction, float DeltaTime);
+    void ProcessKey(CameraMovement Direction, float DeltaTime, float Amount = 1.0f);
+
+    /**
+     * @brief Apply controller dead zone and normalize remaining travel.
+     *
+     * @param Value Axis value
+     * @return float Normalized axis value
+     */
+    float ApplyControllerDeadZone(float Value);
+
+    /**
+     * @brief Convert GLFW trigger axis value to a normalized 0.0-1.0 value.
+     *
+     * @param Value Trigger axis value
+     * @return float Normalized trigger value
+     */
+    float NormalizeTrigger(float Value);
 
 
 
@@ -124,7 +156,7 @@ public:
      * 
      * @param Camera 
      */
-    ERS_CLASS_InputProcessor(ERS_STRUCT_Camera* Camera, GLFWwindow* Window);
+    ERS_CLASS_InputProcessor(ERS_STRUCT_Camera* Camera, GLFWwindow* Window, ERS_CLASS_ControllerInputManager* ControllerInputManager = nullptr);
 
     /**
      * @brief Destroy the Input Processor object
@@ -141,8 +173,23 @@ public:
      * 
      * @param DeltaTime 
      * @param WindowCaptureEnabled 
+     * @param ControllerCaptureEnabled
      */
-    void Process(float DeltaTime, bool WindowCaptureEnabled);
+    void Process(float DeltaTime, bool WindowCaptureEnabled, bool ControllerCaptureEnabled = false);
+
+    /**
+     * @brief Returns true when a controller has viewport navigation input active.
+     *
+     * @return bool
+     */
+    bool HasControllerInput();
+
+    /**
+     * @brief Set the controller input manager used for viewport navigation.
+     *
+     * @param ControllerInputManager
+     */
+    void SetControllerInputManager(ERS_CLASS_ControllerInputManager* ControllerInputManager);
 
 
     /**

--- a/Source/Core/Renderer/ERS_CLASS_VisualRenderer/VisualRenderer.cpp
+++ b/Source/Core/Renderer/ERS_CLASS_VisualRenderer/VisualRenderer.cpp
@@ -154,13 +154,14 @@ glm::vec3 ERS_FUNCTION_GetViewportRay(
 } // namespace
 
 
-ERS_CLASS_VisualRenderer::ERS_CLASS_VisualRenderer(ERS_STRUCT_SystemUtils* SystemUtils, ERS_STRUCT_ProjectUtils* ProjectUtils, GLFWwindow* Window, Cursors3D* Cursors3D) {
+ERS_CLASS_VisualRenderer::ERS_CLASS_VisualRenderer(ERS_STRUCT_SystemUtils* SystemUtils, ERS_STRUCT_ProjectUtils* ProjectUtils, GLFWwindow* Window, Cursors3D* Cursors3D, ERS_CLASS_ControllerInputManager* ControllerInputManager) {
 
     SystemUtils->Logger_->Log("Populating Renderer Member Pointers", 5);
     SystemUtils_ = SystemUtils;
     ProjectUtils_ = ProjectUtils;
     Window_ = Window;
     Cursors3D_ = Cursors3D;
+    ControllerInputManager_ = ControllerInputManager;
 
     SystemUtils_->Logger_->Log("Initializing MeshRenderer Class", 5);
     MeshRenderer_ = std::make_unique<ERS_CLASS_MeshRenderer>(SystemUtils_);
@@ -251,6 +252,7 @@ void ERS_CLASS_VisualRenderer::UpdateViewports(float DeltaTime, ERS_CLASS_SceneM
     glEnable(GL_DEPTH_TEST);
     CaptureCursor_ = false;
     CaptureIndex_ = -1;
+    ControllerCaptureIndex_ = -1;
     FrameNumber_++;
 
     
@@ -291,11 +293,16 @@ void ERS_CLASS_VisualRenderer::UpdateViewports(float DeltaTime, ERS_CLASS_SceneM
             CaptureEnabled = true;
         }
 
+        bool ControllerCaptureEnabled = false;
+        if ((ControllerCaptureIndex_ == i) && (!Cursors3D_->IsUsing())) {
+            ControllerCaptureEnabled = true;
+        }
+
 
 
         // Update Viewport Camera/Position/Etc.
         if (IsEditorMode_ || i != 0) {
-            InputProcessorInstance->Process(DeltaTime, CaptureEnabled);
+            InputProcessorInstance->Process(DeltaTime, CaptureEnabled, ControllerCaptureEnabled);
         } else {
             CaptureEnabled = false;
         }
@@ -559,6 +566,12 @@ void ERS_CLASS_VisualRenderer::UpdateViewport(int Index, ERS_CLASS_SceneManager*
         } else {
             EnableCursorCapture = false;
             Viewport->WasSelected = false;
+        }
+
+        if (EnableCameraMovement && ImGui::IsWindowFocused() && Viewport->Processor->HasControllerInput()) {
+            if (IsEditorMode_ || Index != 0) {
+                ControllerCaptureIndex_ = Index;
+            }
         }
 
 
@@ -830,7 +843,7 @@ void ERS_CLASS_VisualRenderer::CreateViewport(std::string ViewportName) {
 
     // Create Input Processor
     SystemUtils_->Logger_->Log("Creating New Input Processor", 4);
-    Viewport->Processor = std::make_unique<ERS_CLASS_InputProcessor>(Viewport->Camera.get(), Window_);
+    Viewport->Processor = std::make_unique<ERS_CLASS_InputProcessor>(Viewport->Camera.get(), Window_, ControllerInputManager_);
 
     // Create Framebuffer
     unsigned int FramebufferObject;

--- a/Source/Core/Renderer/ERS_CLASS_VisualRenderer/VisualRenderer.h
+++ b/Source/Core/Renderer/ERS_CLASS_VisualRenderer/VisualRenderer.h
@@ -42,6 +42,7 @@
 #include <Viewport.h>
 #include <Shader.h>
 #include <Model.h>
+#include <ControllerInputManager.h>
 #include <OpenGLDefaults.h>
 #include <ProjectUtils.h>
 #include <ShaderUniformData.h>
@@ -66,6 +67,7 @@ private:
     Cursors3D*                 Cursors3D_          = nullptr; /**<Setup 3D Cursor Class*/
     ERS_STRUCT_OpenGLDefaults* OpenGLDefaults_     = nullptr; /**<Pointer acquired from renderermanager*/
     ERS_STRUCT_ProjectUtils*   ProjectUtils_       = nullptr; /**<Project Utils pointer, used to get info about scripts*/
+    ERS_CLASS_ControllerInputManager* ControllerInputManager_ = nullptr; /**<Controller state used by viewport controls*/
     ERS_STRUCT_Shader*         DepthMapShader_     = nullptr; /**<Depth Map Shader Pointer*/
     ERS_STRUCT_Shader*         CubemapDepthShader_ = nullptr; /**<Cubemap Depth Shader*/
     
@@ -89,6 +91,7 @@ public:
 
     bool   CaptureCursor_  = false; /**<Indicate if cursor should be captured*/
     int    CaptureIndex_   = 0;     /**<Index where cursor was captured*/
+    int    ControllerCaptureIndex_ = -1; /**<Index where controller input is routed*/
     int    DefaultShader_  = 0;     /**<Index of default shader program to be used*/
     int    SelectedScript_ = -1;    /**<Set the selected script index*/
     double RunTime_        = -1.0f; /**<Number of seconds since start of "play" mode. (other mode is editor mode)*/
@@ -139,7 +142,7 @@ public:
      * @param Window 
      * @param Cursors3D 
      */
-    ERS_CLASS_VisualRenderer(ERS_STRUCT_SystemUtils* SystemUtils, ERS_STRUCT_ProjectUtils* ProjectUtils, GLFWwindow* Window, Cursors3D* Cursors3D);
+    ERS_CLASS_VisualRenderer(ERS_STRUCT_SystemUtils* SystemUtils, ERS_STRUCT_ProjectUtils* ProjectUtils, GLFWwindow* Window, Cursors3D* Cursors3D, ERS_CLASS_ControllerInputManager* ControllerInputManager = nullptr);
 
     /**
      * @brief Destroy the Visual Renderer object


### PR DESCRIPTION
Fixes #247.

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

Summary:
- Route the existing controller input manager into the visual renderer's viewport input processors.
- Add controller navigation to focused editor viewports: left stick moves the camera, right stick looks around, triggers and bumpers move vertically.
- Keep mouse capture behavior separate from controller capture so controller movement does not hide the cursor.
- Link the visual renderer target against `ERS_ControllerInputManager` for the new header dependency.

Verification:
- `git diff --check`
- Focused `clang++ -std=c++17 -fsyntax-only` check for `InputProcessor.cpp` using local stubs for unavailable logger/system headers and a modern GLFW gamepad header surface.

Known local build blocker:
- Full CMake configure still cannot run in this checkout because `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` is missing and no Unix Makefiles build program is configured (`CMAKE_MAKE_PROGRAM` unset).
