### PR TITLE
Add project export menu action

### DIFF
--- a/Source/Core/Editor/Menus/GUI_Menu_File/CMakeLists.txt
+++ b/Source/Core/Editor/Menus/GUI_Menu_File/CMakeLists.txt
@@ -15,9 +15,13 @@ add_library(Menu_File
             ${BACKWARD_ENABLE}
             )
 
+set_property(TARGET Menu_File PROPERTY CXX_STANDARD 17)
+
 # Link 3rd Party Libs
 target_link_libraries(Menu_File
     IMGUI
+    ImGuiFileDialog
+    ghcFilesystem::ghc_filesystem
     yaml-cpp
     )
 

--- a/Source/Core/Editor/Menus/GUI_Menu_File/GUI_Menu_File.cpp
+++ b/Source/Core/Editor/Menus/GUI_Menu_File/GUI_Menu_File.cpp
@@ -4,6 +4,37 @@
 
 #include <GUI_Menu_File.h>
 
+namespace {
+
+std::string ERS_FUNCTION_NormalizePathString(ghc::filesystem::path Path) {
+
+    std::string Output = ghc::filesystem::absolute(Path).u8string();
+    while ((Output.size() > 1) && ((Output.back() == '/') || (Output.back() == '\\'))) {
+        Output.pop_back();
+    }
+    return Output;
+
+}
+
+bool ERS_FUNCTION_IsSameOrChildPath(const ghc::filesystem::path& Path, const ghc::filesystem::path& PossibleParent) {
+
+    std::string NormalizedPath = ERS_FUNCTION_NormalizePathString(Path);
+    std::string NormalizedParent = ERS_FUNCTION_NormalizePathString(PossibleParent);
+
+    if (NormalizedPath == NormalizedParent) {
+        return true;
+    }
+
+    if (NormalizedParent.back() != '/') {
+        NormalizedParent += "/";
+    }
+
+    return NormalizedPath.rfind(NormalizedParent, 0) == 0;
+
+}
+
+} // namespace
+
 
 GUI_Menu_File::GUI_Menu_File(ERS_STRUCT_SystemUtils* SystemUtils, ERS_CLASS_SceneManager* SceneManager, ERS_STRUCT_ProjectUtils* ProjectUtils, ERS_STRUCT_Windows* Windows) {
 
@@ -25,6 +56,114 @@ GUI_Menu_File::~GUI_Menu_File() {
 
 }
 
+void GUI_Menu_File::SaveCurrentProject() {
+
+    SystemUtils_->Logger_->Log("Saving Project Data", 4);
+    ProjectUtils_->ProjectManager_->WriteProject(1);
+
+    SystemUtils_->Logger_->Log("Saving All Scenes", 4);
+    for (int i = 0; (long)i < (long)SceneManager_->Scenes_.size(); i++) {
+        SystemUtils_->Logger_->Log(std::string("Saving Data For Scene ") + std::to_string(i), 3);
+        SceneWriter_->ProcessScene(
+            SceneManager_->Scenes_[i].get(),
+            SceneManager_->Scenes_[i]->ScenePath
+            );
+    }
+
+}
+
+void GUI_Menu_File::DrawExportProjectDialog() {
+
+    if (ImGuiFileDialog::Instance()->Display("Export Project", ImGuiWindowFlags_None, ImVec2(800, 500))) {
+
+        if (ImGuiFileDialog::Instance()->IsOk()) {
+            ghc::filesystem::path ExportDirectory = ImGuiFileDialog::Instance()->GetCurrentPath();
+            SystemUtils_->Logger_->Log(std::string("Exporting Project To Directory '") + ExportDirectory.u8string() + "'", 5);
+
+            SaveCurrentProject();
+            ExportCurrentProject(ExportDirectory);
+        }
+
+        ImGuiFileDialog::Instance()->Close();
+    }
+
+}
+
+ghc::filesystem::path GUI_Menu_File::GetCurrentProjectDirectory() {
+
+    for (unsigned long i = 0; i < SystemUtils_->Arguments_.size(); i++) {
+        if (SystemUtils_->Arguments_[i].first == std::string("ProjectDirectory")) {
+            return ghc::filesystem::path(SystemUtils_->Arguments_[i].second);
+        }
+    }
+
+    if (SystemUtils_->LocalSystemConfiguration_ != nullptr) {
+        YAML::Node DefaultProjectDirectory = (*SystemUtils_->LocalSystemConfiguration_)["DefaultProjectDirectory"];
+        if (DefaultProjectDirectory.IsDefined()) {
+            return ghc::filesystem::path(DefaultProjectDirectory.as<std::string>());
+        }
+    }
+
+    return ghc::filesystem::path();
+
+}
+
+bool GUI_Menu_File::ExportCurrentProject(ghc::filesystem::path ExportDirectory) {
+
+    ghc::filesystem::path SourceDirectory = GetCurrentProjectDirectory();
+    if (SourceDirectory.empty()) {
+        SystemUtils_->Logger_->Log("Cannot Export Project, Current Project Directory Is Unknown", 8);
+        return false;
+    }
+
+    SourceDirectory = ghc::filesystem::absolute(SourceDirectory);
+    ExportDirectory = ghc::filesystem::absolute(ExportDirectory);
+
+    if (!ghc::filesystem::exists(SourceDirectory) || !ghc::filesystem::is_directory(SourceDirectory)) {
+        SystemUtils_->Logger_->Log(std::string("Cannot Export Project, Source Directory Does Not Exist: ") + SourceDirectory.u8string(), 8);
+        return false;
+    }
+
+    if (ERS_FUNCTION_IsSameOrChildPath(ExportDirectory, SourceDirectory)) {
+        SystemUtils_->Logger_->Log("Cannot Export Project Into The Active Project Directory", 8);
+        return false;
+    }
+
+    try {
+        ghc::filesystem::create_directories(ExportDirectory);
+
+        std::string SourcePrefix = ERS_FUNCTION_NormalizePathString(SourceDirectory);
+        if (SourcePrefix.back() != '/') {
+            SourcePrefix += "/";
+        }
+
+        for (const auto& Entry : ghc::filesystem::recursive_directory_iterator(SourceDirectory)) {
+            ghc::filesystem::path SourcePath = Entry.path();
+            std::string SourcePathString = SourcePath.u8string();
+            if (SourcePathString.rfind(SourcePrefix, 0) != 0) {
+                continue;
+            }
+
+            std::string RelativePath = SourcePathString.substr(SourcePrefix.size());
+            ghc::filesystem::path TargetPath = ExportDirectory / RelativePath;
+
+            if (ghc::filesystem::is_directory(SourcePath)) {
+                ghc::filesystem::create_directories(TargetPath);
+            } else if (ghc::filesystem::is_regular_file(SourcePath)) {
+                ghc::filesystem::create_directories(TargetPath.parent_path());
+                ghc::filesystem::copy_file(SourcePath, TargetPath, ghc::filesystem::copy_options::overwrite_existing);
+            }
+        }
+    } catch (const ghc::filesystem::filesystem_error& Error) {
+        SystemUtils_->Logger_->Log(std::string("Failed To Export Project: ") + Error.what(), 8);
+        return false;
+    }
+
+    SystemUtils_->Logger_->Log(std::string("Finished Exporting Project To '") + ExportDirectory.u8string() + "'", 4);
+    return true;
+
+}
+
 void GUI_Menu_File::Draw() {
 
     // File Menu
@@ -37,18 +176,10 @@ void GUI_Menu_File::Draw() {
 
         ImGui::Separator();
         if (ImGui::MenuItem("Save")) {
-
-            SystemUtils_->Logger_->Log("Saving Project Data", 4);
-            ProjectUtils_->ProjectManager_->WriteProject(1);
-
-            SystemUtils_->Logger_->Log("Saving All Scenes", 4);
-            for (int i = 0; (long)i < (long)SceneManager_->Scenes_.size(); i++) {
-                SystemUtils_->Logger_->Log(std::string("Saving Data For Scene ") + std::to_string(i), 3);
-                SceneWriter_->ProcessScene(
-                    SceneManager_->Scenes_[i].get(),
-                    SceneManager_->Scenes_[i]->ScenePath
-                    );
-            }
+            SaveCurrentProject();
+        }
+        if (ImGui::MenuItem("Export Project")) {
+            ImGuiFileDialog::Instance()->OpenDialog("Export Project", "Export Project", nullptr, "~", "", 0);
         }
 
         ImGui::MenuItem("Project Settings", "", &Windows_->GUI_Window_ProjectSettings_->Enabled_);
@@ -70,6 +201,7 @@ void GUI_Menu_File::Draw() {
     ImGui::EndMenu();
     }
 
+    DrawExportProjectDialog();
 
 
 }

--- a/Source/Core/Editor/Menus/GUI_Menu_File/GUI_Menu_File.h
+++ b/Source/Core/Editor/Menus/GUI_Menu_File/GUI_Menu_File.h
@@ -16,6 +16,10 @@
 
 #include <imgui.h>
 
+#include <ImGuiFileDialog.h>
+
+#include <ghc/filesystem.hpp>
+
 
 // Internal Libraries (BG convention: use <> instead of "")
 #include <BG/Common/Logger/Logger.h>
@@ -48,6 +52,36 @@ private:
     ERS_CLASS_SceneManager* SceneManager_     = nullptr; /**<Scene Manager Instance Pointer*/
     ERS_STRUCT_ProjectUtils* ProjectUtils_    = nullptr; /**<Pointer To Project Utils Instance*/
     std::unique_ptr<SceneWriter> SceneWriter_;           /**<Scene Writer Instance Pointer*/
+
+private:
+
+    /**
+     * @brief Save the active project and all loaded scenes.
+     *
+     */
+    void SaveCurrentProject();
+
+    /**
+     * @brief Draw the export-project directory picker and process accepted exports.
+     *
+     */
+    void DrawExportProjectDialog();
+
+    /**
+     * @brief Resolve the current project directory from launch args or local configuration.
+     *
+     * @return ghc::filesystem::path
+     */
+    ghc::filesystem::path GetCurrentProjectDirectory();
+
+    /**
+     * @brief Copy the active project directory to the target directory.
+     *
+     * @param ExportDirectory
+     * @return true
+     * @return false
+     */
+    bool ExportCurrentProject(ghc::filesystem::path ExportDirectory);
 
 public:
 


### PR DESCRIPTION
Fixes #383.

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

Summary:
- Add `File > Export Project` using the existing ImGui directory picker.
- Reuse the existing save flow before export by writing project asset `1` and serializing every loaded scene.
- Resolve the active project directory from `-ProjectDirectory`, falling back to `DefaultProjectDirectory` from local config.
- Recursively copy the active project directory into the selected export directory, overwriting matching files and rejecting exports into the active project directory itself.

Verification:
- `git diff --check`
- Focused `clang++ -std=c++17 -fsyntax-only` check for `GUI_Menu_File.cpp` using local stubs for unavailable logger/system/window/project headers and filesystem/dialog dependencies.

Known local build blocker:
- Full CMake configure still cannot run in this checkout because `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` is missing and no Unix Makefiles build program is configured (`CMAKE_MAKE_PROGRAM` unset).
