### PR TITLE
Add optional Tracy profiling instrumentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required (VERSION 3.1...3.21)
 
 # Set Configuration Options
 option(ENABLE_BACKWARD "Build ERS With Backward to provide some stack trace information or not" ON)
+option(ENABLE_TRACY "Build ERS With Tracy profiling instrumentation enabled" OFF)
 
 
 # Set Dirs
@@ -73,6 +74,11 @@ find_package(bg-common-logger CONFIG REQUIRED)
 message(STATUS "Finding bg-ers-iosubsystem Package")
 find_package(bg-ers-iosubsystem CONFIG REQUIRED)
 
+if(ENABLE_TRACY)
+    message(STATUS "Finding Tracy Package")
+    find_package(Tracy CONFIG REQUIRED)
+endif()
+
 
 # Include Util CMake Scripts
 include(${CMAKE_UTIL_DIR}/ColorizeMessages.cmake)
@@ -120,6 +126,8 @@ add_subdirectory(${SRC_DIR}/Internal/LocalConfigLoader)
 message(STATUS "Configured Internal Library 'LocalConfigLoader'")
 add_subdirectory(${SRC_DIR}/Internal/GetExecutablePath)
 message(STATUS "Configured Internal Library 'GetExecutablePath'")
+add_subdirectory(${SRC_DIR}/Internal/Profiling)
+message(STATUS "Configured Internal Library 'Profiling'")
 
 ERSBuildLogger(${BoldGreen} "Finished Configuring Internal Libraries")
 
@@ -236,6 +244,7 @@ target_link_libraries("ERS"
     ERS_STRUCT_ProjectUtils
     ERS_STRUCT_RendererSettings
 
+    ERS_Profiling
     Renderer
 )
 target_include_directories("ERS" PRIVATE ${SRC_DIR})

--- a/Source/Core/Renderer/ERS_CLASS_RendererManager/CMakeLists.txt
+++ b/Source/Core/Renderer/ERS_CLASS_RendererManager/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(Renderer
     ERS_STRUCT_HumanInputDeviceUtils
     ERS_STRUCT_OpenGLDefaults
 
+    ERS_Profiling
     ERS_VersioningSystem
     )
 

--- a/Source/Core/Renderer/ERS_CLASS_RendererManager/RendererManager.cpp
+++ b/Source/Core/Renderer/ERS_CLASS_RendererManager/RendererManager.cpp
@@ -3,6 +3,7 @@
 //======================================================================//
 
 #include <RendererManager.h>
+// cppcheck-suppress missingIncludeSystem
 #include <Profiling.h>
 
 

--- a/Source/Core/Renderer/ERS_CLASS_RendererManager/RendererManager.cpp
+++ b/Source/Core/Renderer/ERS_CLASS_RendererManager/RendererManager.cpp
@@ -3,6 +3,7 @@
 //======================================================================//
 
 #include <RendererManager.h>
+#include <Profiling.h>
 
 
 // FIXME! MAKE MORE CLEAN LOOKING OR SOMETHING
@@ -194,6 +195,7 @@ void RendererManager::InitializeGLFW() {
 }
 
 void RendererManager::UpdateLoop(float DeltaTime) { 
+    ERS_PROFILE_NAMED_SCOPE("RendererManager::UpdateLoop");
 
     // Log Any Issues
     ReportOpenGLErrors();

--- a/Source/Core/Renderer/ERS_CLASS_VisualRenderer/CMakeLists.txt
+++ b/Source/Core/Renderer/ERS_CLASS_VisualRenderer/CMakeLists.txt
@@ -90,7 +90,7 @@ target_link_libraries(ERS_CLASS_VisualRenderer
     ERS_STRUCT_RendererSettings
     ERS_STRUCT_ShaderUniformData
 
+    ERS_Profiling
     )
 
 target_include_directories(ERS_CLASS_VisualRenderer PUBLIC ./)
-

--- a/Source/Core/Renderer/ERS_CLASS_VisualRenderer/VisualRenderer.cpp
+++ b/Source/Core/Renderer/ERS_CLASS_VisualRenderer/VisualRenderer.cpp
@@ -3,6 +3,7 @@
 //======================================================================//
 
 #include <VisualRenderer.h>
+#include <Profiling.h>
 
 #include <algorithm>
 #include <cmath>
@@ -205,6 +206,7 @@ void ERS_CLASS_VisualRenderer::SetOpenGLDefaults(ERS_STRUCT_OpenGLDefaults* Defa
 }
 
 void ERS_CLASS_VisualRenderer::UpdateViewports(float DeltaTime, ERS_CLASS_SceneManager* SceneManager) {
+    ERS_PROFILE_NAMED_SCOPE("VisualRenderer::UpdateViewports");
 
     
 
@@ -450,6 +452,7 @@ void ERS_CLASS_VisualRenderer::SetScriptDebug(int Index, std::vector<std::string
 }
 
 void ERS_CLASS_VisualRenderer::UpdateViewport(int Index, ERS_CLASS_SceneManager* SceneManager, float DeltaTime, bool DrawCursor) {
+    ERS_PROFILE_NAMED_SCOPE("VisualRenderer::UpdateViewport");
 
     //todo: check if is Viewport0. then check if the system is in running mode or editor mode. if it's both, then do the following:
     // on transition, store the current editor position / rotation of the camera

--- a/Source/Core/Renderer/ERS_CLASS_VisualRenderer/VisualRenderer.cpp
+++ b/Source/Core/Renderer/ERS_CLASS_VisualRenderer/VisualRenderer.cpp
@@ -3,6 +3,7 @@
 //======================================================================//
 
 #include <VisualRenderer.h>
+// cppcheck-suppress missingIncludeSystem
 #include <Profiling.h>
 
 #include <algorithm>

--- a/Source/Internal/Profiling/CMakeLists.txt
+++ b/Source/Internal/Profiling/CMakeLists.txt
@@ -1,0 +1,12 @@
+########################################################################
+# This file is part of the BrainGenix-ERS Environment Rendering System #
+########################################################################
+
+add_library(ERS_Profiling INTERFACE)
+
+target_include_directories(ERS_Profiling INTERFACE ./)
+
+if(ENABLE_TRACY)
+    target_compile_definitions(ERS_Profiling INTERFACE ERS_ENABLE_TRACY TRACY_ENABLE)
+    target_link_libraries(ERS_Profiling INTERFACE Tracy::TracyClient)
+endif()

--- a/Source/Internal/Profiling/Profiling.h
+++ b/Source/Internal/Profiling/Profiling.h
@@ -1,0 +1,21 @@
+//======================================================================//
+// This file is part of the BrainGenix-ERS Environment Rendering System //
+//======================================================================//
+
+#pragma once
+
+#ifdef ERS_ENABLE_TRACY
+
+#include <tracy/Tracy.hpp>
+
+#define ERS_PROFILE_SCOPE() ZoneScoped
+#define ERS_PROFILE_NAMED_SCOPE(Name) ZoneScopedN(Name)
+#define ERS_PROFILE_FRAME_MARK() FrameMark
+
+#else
+
+#define ERS_PROFILE_SCOPE() do {} while (0)
+#define ERS_PROFILE_NAMED_SCOPE(Name) do { (void)sizeof(Name); } while (0)
+#define ERS_PROFILE_FRAME_MARK() do {} while (0)
+
+#endif

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -47,8 +47,8 @@
 //#include <PythonInterpreterIntegration.h>
 #include <ERS_CLASS_LuaJITInterpreterIntegration.h>
 
-
 #include <GetExecutablePath.h>
+#include <Profiling.h>
 
 
 //
@@ -175,6 +175,7 @@ int main(int NumArguments, char** ArguemntValues) {
 
     // Enter Main Loop
     while (*SystemUtils->SystemShouldRun_) {
+        ERS_PROFILE_NAMED_SCOPE("Main Loop");
 
         // Calculate Frametime
         float CurrentTime = glfwGetTime();
@@ -197,6 +198,7 @@ int main(int NumArguments, char** ArguemntValues) {
 
         // End Frame
         SystemUtils->FramerateManager_->DelayUntilNextFrame();
+        ERS_PROFILE_FRAME_MARK();
 
     }
 

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -48,6 +48,7 @@
 #include <ERS_CLASS_LuaJITInterpreterIntegration.h>
 
 #include <GetExecutablePath.h>
+// cppcheck-suppress missingIncludeSystem
 #include <Profiling.h>
 
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -12,6 +12,7 @@
     "ghc-filesystem",
     "infoware",
     "lua",
+    "tracy",
 
     "bg-ers-iosubsystem"
 


### PR DESCRIPTION
## Summary
- add an opt-in `ENABLE_TRACY` build flag and Tracy vcpkg dependency
- add an `ERS_Profiling` interface target with Tracy/no-op profiling macros
- mark the main loop, renderer update loop, viewport updates, and frame boundary for Tracy captures

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

Fixes #103

## Verification
- `git diff --check`
- focused no-Tracy syntax check for `Source/Internal/Profiling/Profiling.h`
- `cmake -S . -B Build/ers-103-check` still stops on the existing local environment blocker: missing `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` and no Unix Makefiles build program (`CMAKE_MAKE_PROGRAM` unset)
