### PR TITLE
Add adaptive viewport motion blur

### DIFF
--- a/Source/Core/Editor/Windows/GUI_Window_RenderingSettings/GUI_Window_RenderingSettings.cpp
+++ b/Source/Core/Editor/Windows/GUI_Window_RenderingSettings/GUI_Window_RenderingSettings.cpp
@@ -92,6 +92,17 @@ void GUI_Window_RenderingSettings::Draw() {
                 ImGui::ColorEdit4("Background Clear Color", (float*)&ClearColor_);
                 ImGui::NewLine();
 
+                // Adaptive Motion Blur Settings
+                ImGui::Separator();
+                ImGui::TextColored(ImVec4(0.2f, 0.8f, 0.2f, 1.0f), "Adaptive Motion Blur");
+                ImGui::Separator();
+
+                ImGui::Checkbox("Enable Motion Blur", &Settings->MotionBlurEnabled_);
+                ImGui::DragFloat("Motion Blur Strength", &Settings->MotionBlurStrength_, 0.01f, 0.0f, 2.0f);
+                ImGui::DragFloat("Reference Framerate", &Settings->MotionBlurReferenceFrameRate_, 1.0f, 1.0f, 240.0f);
+                ImGui::DragFloat("Maximum Blend", &Settings->MotionBlurMaxBlend_, 0.01f, 0.0f, 0.95f);
+                ImGui::NewLine();
+
 
                 // Framerate Settings
                 ImGui::Separator();

--- a/Source/Core/Renderer/ERS_CLASS_VisualRenderer/ViewportMenu.cpp
+++ b/Source/Core/Renderer/ERS_CLASS_VisualRenderer/ViewportMenu.cpp
@@ -157,6 +157,7 @@ void ERS_CLASS_ViewportMenu::DrawMenu(ERS_STRUCT_Viewport* Viewport, ERS_CLASS_S
 
             ImGui::MenuItem("Gamma Correction", nullptr, &Viewport->GammaCorrection);
             ImGui::MenuItem("HDR", nullptr, &Viewport->HDREnabled_);
+            ImGui::MenuItem("Adaptive Motion Blur", nullptr, &Viewport->MotionBlurEnabled_);
 
 
         ImGui::EndMenu();

--- a/Source/Core/Renderer/ERS_CLASS_VisualRenderer/VisualRenderer.cpp
+++ b/Source/Core/Renderer/ERS_CLASS_VisualRenderer/VisualRenderer.cpp
@@ -734,7 +734,7 @@ void ERS_CLASS_VisualRenderer::UpdateViewport(int Index, ERS_CLASS_SceneManager*
 
             if (MotionBlurBlend > 0.0f) {
                 ImGui::GetWindowDrawList()->AddImage(
-                    (void*)(intptr_t)Viewport->MotionBlurHistoryTextureObject,
+                    reinterpret_cast<void*>(static_cast<intptr_t>(Viewport->MotionBlurHistoryTextureObject)),
                     ImGui::GetCursorScreenPos(),
                     ImVec2(ImGui::GetCursorScreenPos().x + ImGui::GetWindowSize().x, ImGui::GetCursorScreenPos().y + ImGui::GetWindowSize().y),
                     ImVec2(0, 1),

--- a/Source/Core/Renderer/ERS_CLASS_VisualRenderer/VisualRenderer.cpp
+++ b/Source/Core/Renderer/ERS_CLASS_VisualRenderer/VisualRenderer.cpp
@@ -186,6 +186,7 @@ ERS_CLASS_VisualRenderer::~ERS_CLASS_VisualRenderer() {
 
         glDeleteFramebuffers(1, &Viewports_[i]->FramebufferObject);
         glDeleteTextures(1, &Viewports_[i]->FramebufferColorObject);
+        glDeleteTextures(1, &Viewports_[i]->MotionBlurHistoryTextureObject);
         glDeleteRenderbuffers(1, &Viewports_[i]->RenderbufferObject);
 
     }
@@ -568,12 +569,21 @@ void ERS_CLASS_VisualRenderer::UpdateViewport(int Index, ERS_CLASS_SceneManager*
         glViewport(0, 0, RenderWidth, RenderHeight);
         glScissor(0, 0, RenderWidth, RenderHeight);
 
+        ERS_STRUCT_RendererSettings* RendererSettings = SystemUtils_->RendererSettings_.get();
 
         // Resize Viewport If Needed
         if ((RenderWidth != Viewport->Width) || (RenderHeight != Viewport->Height)) {
             ResizeViewport(Index, RenderWidth, RenderHeight);
         }
 
+        // Copy Last Frame To Motion Blur History Before This Frame Clears The FBO
+        if (RendererSettings->MotionBlurEnabled_ && Viewport->MotionBlurEnabled_ && Viewport->MotionBlurFrameReady_) {
+            glBindFramebuffer(GL_FRAMEBUFFER, Viewport->FramebufferObject);
+            glReadBuffer(GL_COLOR_ATTACHMENT0);
+            glBindTexture(GL_TEXTURE_2D, Viewport->MotionBlurHistoryTextureObject);
+            glCopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 0, 0, RenderWidth, RenderHeight);
+            Viewport->MotionBlurHistoryReady_ = true;
+        }
 
         // Bind To Framebuffer
         glBindFramebuffer(GL_FRAMEBUFFER, Viewport->FramebufferObject);
@@ -713,6 +723,27 @@ void ERS_CLASS_VisualRenderer::UpdateViewport(int Index, ERS_CLASS_SceneManager*
             ImVec2(0, 1),
             ImVec2(1, 0)
         );
+        if (RendererSettings->MotionBlurEnabled_ && Viewport->MotionBlurEnabled_ && Viewport->MotionBlurHistoryReady_) {
+            float MotionBlurBlend = RendererSettings->MotionBlurStrength_ * DeltaTime * RendererSettings->MotionBlurReferenceFrameRate_;
+            if (MotionBlurBlend < 0.0f) {
+                MotionBlurBlend = 0.0f;
+            }
+            if (MotionBlurBlend > RendererSettings->MotionBlurMaxBlend_) {
+                MotionBlurBlend = RendererSettings->MotionBlurMaxBlend_;
+            }
+
+            if (MotionBlurBlend > 0.0f) {
+                ImGui::GetWindowDrawList()->AddImage(
+                    (void*)(intptr_t)Viewport->MotionBlurHistoryTextureObject,
+                    ImGui::GetCursorScreenPos(),
+                    ImVec2(ImGui::GetCursorScreenPos().x + ImGui::GetWindowSize().x, ImGui::GetCursorScreenPos().y + ImGui::GetWindowSize().y),
+                    ImVec2(0, 1),
+                    ImVec2(1, 0),
+                    ImGui::ColorConvertFloat4ToU32(ImVec4(1.0f, 1.0f, 1.0f, MotionBlurBlend))
+                );
+            }
+        }
+        Viewport->MotionBlurFrameReady_ = true;
 
 
         // Draw 3D Cursor
@@ -765,6 +796,11 @@ void ERS_CLASS_VisualRenderer::ResizeViewport(int Index, int Width, int Height) 
     glBindTexture(GL_TEXTURE_2D, Viewports_[Index]->FramebufferColorObject);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, Width, Height, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
 
+    glBindTexture(GL_TEXTURE_2D, Viewports_[Index]->MotionBlurHistoryTextureObject);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, Width, Height, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
+    Viewports_[Index]->MotionBlurHistoryReady_ = false;
+    Viewports_[Index]->MotionBlurFrameReady_ = false;
+
 
     // Update RBO Size
     glBindRenderbuffer(GL_RENDERBUFFER, Viewports_[Index]->RenderbufferObject);
@@ -780,6 +816,7 @@ void ERS_CLASS_VisualRenderer::DeleteViewport(int Index) {
     // Cleanup OpenGL Objects
     glDeleteFramebuffers(1, &Viewports_[Index]->FramebufferObject);
     glDeleteTextures(1, &Viewports_[Index]->FramebufferColorObject);
+    glDeleteTextures(1, &Viewports_[Index]->MotionBlurHistoryTextureObject);
     glDeleteRenderbuffers(1, &Viewports_[Index]->RenderbufferObject);
 
     // Delete Viewport Struct
@@ -853,6 +890,16 @@ void ERS_CLASS_VisualRenderer::CreateViewport(std::string ViewportName) {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     Viewport->FramebufferColorObject = FramebufferColorObject;
+
+    // Create Motion Blur History Texture
+    unsigned int MotionBlurHistoryTextureObject;
+    SystemUtils_->Logger_->Log("Creating Motion Blur History Texture", 4);
+    glGenTextures(1, &MotionBlurHistoryTextureObject);
+    glBindTexture(GL_TEXTURE_2D, MotionBlurHistoryTextureObject);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 800, 800, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    Viewport->MotionBlurHistoryTextureObject = MotionBlurHistoryTextureObject;
 
 
     // Attach Texture To Framebuffer

--- a/Source/Core/Structures/ERS_STRUCT_RendererSettings/RendererSettings.h
+++ b/Source/Core/Structures/ERS_STRUCT_RendererSettings/RendererSettings.h
@@ -32,6 +32,12 @@ struct ERS_STRUCT_RendererSettings {
     ERS::Renderer::ShadowUpdateMode ShadowUpdateMode_ = ERS::Renderer::ERS_SHADOW_UPDATE_MODE_DISTANCE_PRIORITIZED;
     int MaxShadowUpdatesPerFrame_ = 5;
     int ShadowFilterKernelSize_ = 2;
+
+    // Motion Blur Settings
+    bool MotionBlurEnabled_ = false;
+    float MotionBlurStrength_ = 0.25f;
+    float MotionBlurReferenceFrameRate_ = 60.0f;
+    float MotionBlurMaxBlend_ = 0.85f;
     
     unsigned long long VRAMBudget_ = 0;
     unsigned long long RAMBudget_ = 0;

--- a/Source/Core/Structures/ERS_STRUCT_Viewport/Viewport.h
+++ b/Source/Core/Structures/ERS_STRUCT_Viewport/Viewport.h
@@ -34,6 +34,7 @@ struct ERS_STRUCT_Viewport {
     bool LightIcons                    = true;  /**<Draw or don't draw the light icons*/
     bool GammaCorrection               = true;  /**<Enable/disable gamma correction*/
     bool HDREnabled_                   = true;  /**<Indicate if hdr should be used or not*/
+    bool MotionBlurEnabled_            = true;  /**<Enable adaptive temporal motion blur for this viewport*/
     bool ShowBoundingBox_              = true;  /**<Draw the bounding boxes or don't*/
  
     bool WireframeBoundingBoxes_       = true;  /**<Set bounding boxes to opaque or wireframe*/
@@ -68,6 +69,9 @@ struct ERS_STRUCT_Viewport {
     unsigned int FramebufferObject;      /**<FBO OpenGL ID*/
     unsigned int FramebufferColorObject; /**<FBCO OpenGL ID*/
     unsigned int RenderbufferObject;     /**<RBO OpenGL ID*/
+    unsigned int MotionBlurHistoryTextureObject; /**<Texture containing the previous viewport frame*/
+    bool MotionBlurHistoryReady_ = false; /**<Indicates if the history texture contains a valid previous frame*/
+    bool MotionBlurFrameReady_ = false; /**<Indicates if the viewport framebuffer has rendered at least one frame*/
 
     int Width  = 1; /**<Viewport Width*/
     int Height = 1; /**<Viewport Height*/


### PR DESCRIPTION
Summary:
- Add renderer-level adaptive motion blur controls and a per-viewport toggle.
- Keep a previous-frame texture per viewport and blend it over the current viewport frame when enabled.
- Scale the history-frame blend by DeltaTime * reference frame rate so lower frame rates receive more blur and higher frame rates receive less.

Verification:
- git diff --check
- focused RendererSettings.h syntax check
- focused Viewport.h syntax check with local dependency stubs
- focused ImGui motion-blur tint syntax check
- cmake -S . -B Build/ers-227-check (fails in this checkout because ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake and the Unix Makefiles build program are unavailable)

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

Fixes #227