### PR TITLE
Improve streamed texture minification filtering

### DIFF
--- a/Source/Core/Loader/ERS_ModelLoader/AsyncTextureUpdater.cpp
+++ b/Source/Core/Loader/ERS_ModelLoader/AsyncTextureUpdater.cpp
@@ -4,6 +4,14 @@
 
 #include <AsyncTextureUpdater.h>
 
+#ifndef GL_TEXTURE_MAX_ANISOTROPY_EXT
+#define GL_TEXTURE_MAX_ANISOTROPY_EXT 0x84FE
+#endif
+
+#ifndef GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT
+#define GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT 0x84FF
+#endif
+
 
 ERS_CLASS_AsyncTextureUpdater::ERS_CLASS_AsyncTextureUpdater(ERS_STRUCT_SystemUtils* SystemUtils, ERS_CLASS_AssetStreamingSystemResourceMonitor* ResourceMonitor, GLFWwindow* Window, unsigned int Threads) {
 
@@ -51,6 +59,21 @@ ERS_CLASS_AsyncTextureUpdater::~ERS_CLASS_AsyncTextureUpdater() {
 
 
 // Texture Streaming Helpers
+void ERS_CLASS_AsyncTextureUpdater::ApplyHighFrequencyTextureFiltering() {
+
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
+    if (glfwExtensionSupported("GL_EXT_texture_filter_anisotropic") == GLFW_TRUE) {
+        GLfloat MaxAnisotropy = 1.0f;
+        glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &MaxAnisotropy);
+        if (MaxAnisotropy > 1.0f) {
+            glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, MaxAnisotropy);
+        }
+    }
+
+}
+
 void ERS_CLASS_AsyncTextureUpdater::FreeRAMAllocation(ERS_STRUCT_TextureLevel &Level) {
     if (Level.AllocatedRAMBudget) {
         ResourceMonitor_->DeallocateTextureRAMFromBudget(Level.LevelMemorySizeBytes);
@@ -406,6 +429,8 @@ bool ERS_CLASS_AsyncTextureUpdater::LoadImageDataVRAM(ERS_STRUCT_Texture* Textur
     }
     glFinish();
     glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, Width, Height, TextureExternFormat, GL_UNSIGNED_BYTE, 0);
+    glGenerateMipmap(GL_TEXTURE_2D);
+    ApplyHighFrequencyTextureFiltering();
     
 
     // Cleanup Buffers, Wait For Everything To Finish

--- a/Source/Core/Loader/ERS_ModelLoader/AsyncTextureUpdater.h
+++ b/Source/Core/Loader/ERS_ModelLoader/AsyncTextureUpdater.h
@@ -75,6 +75,7 @@ private:
 
     void TexturePusherThread(int Index);
     void TextureLoaderThread(int Index);
+    void ApplyHighFrequencyTextureFiltering();
 
 
     void FreeRAMAllocation(ERS_STRUCT_TextureLevel &Level);
@@ -243,4 +244,3 @@ public:
 
 
 };
-


### PR DESCRIPTION
Fixes #342.

This adds a focused texture-sampling fix for high-frequency model texture detail in the streamed texture path.

Included in this patch:

- generates mipmaps after streamed model texture data is uploaded to OpenGL
- switches streamed model textures from single-level `GL_LINEAR` minification to `GL_LINEAR_MIPMAP_LINEAR`
- enables `GL_EXT_texture_filter_anisotropic` at the device-reported maximum when the extension is present
- keeps the existing texture streaming level selection and VRAM/RAM budgeting behavior unchanged

Notes:

- issue #342 has no repro details, screenshots, or asset reference, so this targets the common high-frequency texture aliasing/shimmer class of problems rather than an unknown asset-specific artifact
- depth maps and framebuffer textures intentionally keep their existing filters because they are not sampled as material detail textures

Verification:

- `git diff --check origin/master`
- patch apply against a clean `origin/master` worktree with `git apply --check`
- focused C++17 syntax probe for the new high-frequency filtering helper
- `cmake -S . -B Build/ers-342-check -G "Unix Makefiles"` still fails because this machine is missing `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` and a Unix Makefiles build program (`CMAKE_MAKE_PROGRAM` unset)

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.
