### PR TITLE
Keep duplicated scenes on separate assets

### DIFF
--- a/Source/Core/Editor/Windows/GUI_Window_SceneTree/DuplicateScene.cpp
+++ b/Source/Core/Editor/Windows/GUI_Window_SceneTree/DuplicateScene.cpp
@@ -5,7 +5,7 @@
 #include <DuplicateScene.h>
 
 
-void GUI_Windowutil_DuplicateScene(ERS_CLASS_SceneManager* SceneManager, int SceneIndex) {
+void GUI_Windowutil_DuplicateScene(ERS_CLASS_SceneManager* SceneManager, ERS_STRUCT_SystemUtils* SystemUtils, ERS_STRUCT_ProjectUtils* ProjectUtils, int SceneIndex) {
 
     // Get Current Scene
     ERS_STRUCT_Scene NewScene = *SceneManager->Scenes_[SceneIndex].get();
@@ -14,6 +14,10 @@ void GUI_Windowutil_DuplicateScene(ERS_CLASS_SceneManager* SceneManager, int Sce
     std::string CurrentName = NewScene.SceneName;
     std::string NewName = CurrentName + std::string(" - Copy");
     NewScene.SceneName = NewName;
+    NewScene.ScenePath = SystemUtils->ERS_IOSubsystem_->AllocateAssetID();
+
+    // Add new scene asset to the project so save/reload keeps the duplicate separate.
+    ProjectUtils->ProjectManager_->Project_.SceneIDs.push_back(NewScene.ScenePath);
 
     // Add To SceneManager
     SceneManager->Scenes_.push_back(std::make_unique<ERS_STRUCT_Scene>(NewScene));

--- a/Source/Core/Editor/Windows/GUI_Window_SceneTree/DuplicateScene.h
+++ b/Source/Core/Editor/Windows/GUI_Window_SceneTree/DuplicateScene.h
@@ -14,11 +14,15 @@
 // Internal Libraries (BG convention: use <> instead of "")
 #include <SceneManager.h>
 #include <Scene.h>
+#include <SystemUtils.h>
+#include <ProjectUtils.h>
 
 /**
  * @brief Duplicate the scene in the project
  * 
  * @param SceneManager 
- * @param SceneIndex 
+ * @param SystemUtils
+ * @param ProjectUtils
+ * @param SceneIndex
  */
-void GUI_Windowutil_DuplicateScene(ERS_CLASS_SceneManager* SceneManager, int SceneIndex);
+void GUI_Windowutil_DuplicateScene(ERS_CLASS_SceneManager* SceneManager, ERS_STRUCT_SystemUtils* SystemUtils, ERS_STRUCT_ProjectUtils* ProjectUtils, int SceneIndex);

--- a/Source/Core/Editor/Windows/GUI_Window_SceneTree/GUI_Window_SceneTree.cpp
+++ b/Source/Core/Editor/Windows/GUI_Window_SceneTree/GUI_Window_SceneTree.cpp
@@ -111,7 +111,7 @@ void GUI_Window_SceneTree::Draw() {
                             Subwindow_SceneRenameModal_->Activate(SceneIndex);
                         }
                         if (ImGui::MenuItem("Duplicate")) {
-                            GUI_Windowutil_DuplicateScene(SceneManager_, SceneIndex); // FIXME: Will need to update how scenes are saved, as right now these will overwrite other scenes when saved. (Solution could be a scenes folder?)
+                            GUI_Windowutil_DuplicateScene(SceneManager_, SystemUtils_, ProjectUtils_, SceneIndex);
                         }
 
 
@@ -680,4 +680,3 @@ void GUI_Window_SceneTree::DrawScene(ERS_STRUCT_Scene* Scene, int SceneIndex) {
 
 
 }
-


### PR DESCRIPTION
Addresses an explicit future-work marker in `GUI_Window_SceneTree.cpp` where duplicated scenes reused the original scene asset and could overwrite it during save.

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Summary
- allocate a fresh IOSubsystem asset ID when duplicating a scene
- append the duplicated scene asset ID to the project scene list so File > Save persists it separately
- remove the obsolete duplicate-scene save-overwrite FIXME from the scene tree context menu

## Verification
- `git diff --check`
- clean `origin/master` worktree patch apply check
- focused C++17 duplicate-scene behavior executable probe
- `cmake -S . -B Build/ers-duplicate-scene-check -G "Unix Makefiles"` (still stops on the known local environment blocker: missing `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` and `CMAKE_MAKE_PROGRAM` unset)