### PR TITLE
Save model metadata modification dates

### DIFF
--- a/Source/Core/Writers/ERS_ModelWriter/ModelWriter.cpp
+++ b/Source/Core/Writers/ERS_ModelWriter/ModelWriter.cpp
@@ -371,10 +371,11 @@ void ERS_CLASS_ModelWriter::WriteModel(ERS_STRUCT_ModelWriterData &Data, bool Fl
     IOData.Size_B = Metadata.size();
     memcpy(IOData.Data.get(), Metadata.c_str(), Metadata.size());
 
-    // Set Metadata (FIXME: Save Modification Date + Creation Date Here!)
+    // Set Metadata
     IOData.AssetTypeName = "Model";
     IOData.AssetFileName = Data.ModelFileName;
     IOData.AssetCreationDate = IOSubsystem_->GetCurrentTime();
+    IOData.AssetModificationDate = IOData.AssetCreationDate;
 
     long MetadataID = IOSubsystem_->AllocateAssetID();
     Logger_->Log(std::string(std::string("Assigning ID '") + std::to_string(MetadataID) + std::string("' To Model Metadata")).c_str(), 4);
@@ -382,5 +383,4 @@ void ERS_CLASS_ModelWriter::WriteModel(ERS_STRUCT_ModelWriterData &Data, bool Fl
     IOSubsystem_->WriteAsset(MetadataID, &IOData);
 
 }
-
 


### PR DESCRIPTION
Addresses an explicit future-work marker in `ModelWriter.cpp` to save model metadata creation and modification dates.

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Summary
- write `AssetModificationDate` for model metadata IOData
- keep the initial modification date equal to the model metadata creation date at import time
- remove the obsolete metadata timestamp FIXME

## Verification
- `git diff --check`
- clean `origin/master` worktree patch apply check
- focused C++17 metadata timestamp executable probe
- `cmake -S . -B Build/ers-model-metadata-dates-check -G "Unix Makefiles"` (still stops on the known local environment blocker: missing `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` and `CMAKE_MAKE_PROGRAM` unset)