### PR TITLE
Remove stale shader loader FIXME

### DIFF
--- a/Source/Core/Structures/ERS_STRUCT_Shader/Shader.h
+++ b/Source/Core/Structures/ERS_STRUCT_Shader/Shader.h
@@ -235,6 +235,3 @@ struct ERS_STRUCT_Shader {
     void SetMat4(const std::string &name, const glm::mat4 &mat) const;
 
 };
-
-// FIXME: MOVE THISE TO OTHER (seperate) Shader Loader Class
-


### PR DESCRIPTION
Addresses an explicit future-work marker in `Shader.h` that is already satisfied by the existing `ERS_CLASS_ShaderLoader`.

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Summary
- remove the obsolete shader-loader FIXME from `ERS_STRUCT_Shader`
- verified `ERS_CLASS_ShaderLoader` already provides `CreateShaderObject` and `LoadShaderFromAsset`

## Verification
- `git diff --check`
- clean `origin/master` worktree patch apply check
- source search confirmed shader loading is already isolated in `Source/Core/Loader/ERS_ShaderLoader`