### PR TITLE
Move theme selector controls into theme manager

### DIFF
--- a/Source/Core/Editor/Utils/ERS_Editor_ThemeManager/ThemeManager.cpp
+++ b/Source/Core/Editor/Utils/ERS_Editor_ThemeManager/ThemeManager.cpp
@@ -14,9 +14,10 @@ ERS_CLASS_ThemeManager::ERS_CLASS_ThemeManager(BG::Common::Logger::LoggingSystem
     LoadThemes();
 
     // Default To Dark Mode
-    int Index;
-    for (Index = 0; (long)Index < (long)ThemeNames_.size(); Index++) {
-        if (ThemeNames_[Index] == "Dark") {
+    int Index = 0;
+    for (int i = 0; (long)i < (long)ThemeNames_.size(); i++) {
+        if (ThemeNames_[i] == "Dark") {
+            Index = i;
             break;
         }
     }
@@ -52,8 +53,8 @@ void ERS_CLASS_ThemeManager::ApplyThemes(const char* ThemeName) {
 
 void ERS_CLASS_ThemeManager::LoadThemes() {
 
-    ThemeNames_ = *new std::vector<std::string>;
-    ThemeFiles_ = *new std::vector<YAML::Node>;
+    ThemeNames_.clear();
+    ThemeFiles_.clear();
 
     // Create List Of Files
     for (const auto &Entry : ghc::filesystem::directory_iterator(std::string(ThemePath_))) {
@@ -82,6 +83,39 @@ void ERS_CLASS_ThemeManager::LoadThemes() {
 
 }
 
+void ERS_CLASS_ThemeManager::CreateThemeMenu() {
+
+    static int ThemeSelector = 0;
+    if (ThemeSelector >= static_cast<int>(ThemeNames_.size())) {
+        ThemeSelector = ThemeNames_.empty() ? 0 : static_cast<int>(ThemeNames_.size()) - 1;
+    }
+
+    ImGui::BeginChild("Theme Selector", ImVec2(250, 250), true);
+
+        for (int i = 0; (long)i < (long)ThemeNames_.size(); i++) {
+
+            ImGui::RadioButton(ThemeNames_[i].c_str(), &ThemeSelector, i);
+
+        }
+
+    ImGui::EndChild();
+
+    ImGui::Separator();
+
+    if (ImGui::Button("Reload Themes")) {
+        LoadThemes();
+        if (ThemeSelector >= static_cast<int>(ThemeNames_.size())) {
+            ThemeSelector = ThemeNames_.empty() ? 0 : static_cast<int>(ThemeNames_.size()) - 1;
+        }
+    }
+    ImGui::SameLine();
+
+    if (ImGui::Button("Apply")) {
+        ApplyThemes(ThemeSelector);
+    }
+
+}
+
 ImVec4 ERS_CLASS_ThemeManager::ReadColor(const char* NodeName, YAML::Node Target) {
 
      Logger_->Log(std::string(std::string("Reading Theme For Value: '") + std::string(NodeName) + std::string("'")).c_str(), 1);
@@ -103,6 +137,11 @@ ImVec4 ERS_CLASS_ThemeManager::ReadColor(const char* NodeName, YAML::Node Target
 }
 
 void ERS_CLASS_ThemeManager::ApplyThemes(int ThemeID) {
+
+    if (ThemeID < 0 || static_cast<long>(ThemeID) >= static_cast<long>(ThemeNames_.size()) || static_cast<long>(ThemeID) >= static_cast<long>(ThemeFiles_.size())) {
+        Logger_->Log("Invalid Theme ID, Skipping", 5);
+        return;
+    }
 
     // Get Theme Name
     std::string ThemeName = ThemeNames_[ThemeID];
@@ -229,4 +268,3 @@ void ERS_CLASS_ThemeManager::ApplyThemes(int ThemeID) {
     Style.Colors[ImGuiCol_DockingEmptyBg]        = ReadColor("DockingEmptyBackground", ThemeNode);
     Style.Colors[ImGuiCol_Separator]        = ReadColor("SeperatorColor", ThemeNode);
 }
-

--- a/Source/Core/Editor/Utils/ERS_Editor_ThemeManager/ThemeManager.h
+++ b/Source/Core/Editor/Utils/ERS_Editor_ThemeManager/ThemeManager.h
@@ -77,7 +77,6 @@ public:
      * @brief Create the theme menu
      * 
      */
-    //FIXME: MOVE MENU UPDATE FUNCTION OUT OF GUP INTO THIS FUNCTION!!!!
     void CreateThemeMenu();
 
     /**

--- a/Source/Core/Editor/Windows/GUI_Window_ThemeSelector/GUI_Window_ThemeSelector.cpp
+++ b/Source/Core/Editor/Windows/GUI_Window_ThemeSelector/GUI_Window_ThemeSelector.cpp
@@ -28,33 +28,7 @@ void GUI_Window_ThemeSelector::Draw() {
 
             if (Visible) {
 
-                // Put Radio Buttons Here
-                ImGui::BeginChild("Theme Selector", ImVec2(250, 250), true);
-
-                    static int ThemeSelector = 0;
-                    for (int i = 0; (long)i < (long)ThemeManager_->ThemeNames_.size(); i++) {
-
-                        ImGui::RadioButton(ThemeManager_->ThemeNames_[i].c_str(), &ThemeSelector, i);
-
-                    }
-                    
-
-                ImGui::EndChild();
-
-
-                ImGui::Separator();
-
-
-                // Reload Button
-                if (ImGui::Button("Reload Themes")) {
-                    ThemeManager_->LoadThemes();
-                }
-                ImGui::SameLine();
-
-                // Apply Button
-                if (ImGui::Button("Apply")) {
-                    ThemeManager_->ApplyThemes(ThemeSelector);
-                }
+                ThemeManager_->CreateThemeMenu();
                 ImGui::SameLine();
 
                 // Close Button


### PR DESCRIPTION
## Summary
- implement `ERS_CLASS_ThemeManager::CreateThemeMenu()` and move the theme list/reload/apply controls out of the theme selector window
- keep the theme selector window responsible only for the window shell and Close button
- clamp the selected theme index after reloads and guard invalid `ApplyThemes(int)` calls
- clear existing theme vectors on reload instead of leaking replacement vectors

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `git diff --check`
- source search confirming the theme-manager menu FIXME is gone and `GUI_Window_ThemeSelector` now calls `CreateThemeMenu()`
- focused C++17 selector clamp/apply-bounds probe
- clean `origin/master` patch-apply check
- `cmake -S . -B Build/ers-theme-menu-check -G "Unix Makefiles"` blocked by existing environment issue: missing `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` and no Unix Makefiles build program (`CMAKE_MAKE_PROGRAM` unset)
