### PR TITLE
Persist controller settings profiles

### DIFF
--- a/Source/Core/Loader/ERS_ControllerSettingsLoader/ControllerSettingsLoader.cpp
+++ b/Source/Core/Loader/ERS_ControllerSettingsLoader/ControllerSettingsLoader.cpp
@@ -57,7 +57,7 @@ bool ERS_CLASS_ControllerSettingsLoader::LoadControllerSettings(ERS_STRUCT_Contr
 
         ControllerSettings->MinThresholdJoystickLeftX = SettingsData["MinThresholdJoystickLeftX"].as<float>();
         ControllerSettings->MinThresholdJoystickLeftY = SettingsData["MinThresholdJoystickLeftY"].as<float>();
-        ControllerSettings->MinThresholdJoystickRightX = SettingsData["MinThresholdJoystickLeftX"].as<float>();
+        ControllerSettings->MinThresholdJoystickRightX = SettingsData["MinThresholdJoystickRightX"].as<float>();
         ControllerSettings->MinThresholdJoystickRightY = SettingsData["MinThresholdJoystickRightY"].as<float>();
 
         ControllerSettings->MaxThresholdJoystickLeftX = SettingsData["MaxThresholdJoystickLeftX"].as<float>();
@@ -65,6 +65,18 @@ bool ERS_CLASS_ControllerSettingsLoader::LoadControllerSettings(ERS_STRUCT_Contr
         ControllerSettings->MaxThresholdJoystickRightX = SettingsData["MaxThresholdJoystickRightX"].as<float>();
         ControllerSettings->MaxThresholdJoystickRightY = SettingsData["MaxThresholdJoystickRightY"].as<float>();
 
+        if (SettingsData["MinThresholdTriggerLeft"]) {
+            ControllerSettings->MinThresholdTriggerLeft = SettingsData["MinThresholdTriggerLeft"].as<float>();
+        }
+        if (SettingsData["MinThresholdTriggerRight"]) {
+            ControllerSettings->MinThresholdTriggerRight = SettingsData["MinThresholdTriggerRight"].as<float>();
+        }
+        if (SettingsData["MaxThresholdTriggerLeft"]) {
+            ControllerSettings->MaxThresholdTriggerLeft = SettingsData["MaxThresholdTriggerLeft"].as<float>();
+        }
+        if (SettingsData["MaxThresholdTriggerRight"]) {
+            ControllerSettings->MaxThresholdTriggerRight = SettingsData["MaxThresholdTriggerRight"].as<float>();
+        }
 
         ControllerSettings->JoystickLeftButtonIndex = SettingsData["JoystickLeftButtonIndex"].as<int>();
         ControllerSettings->JoystickRightButtonIndex = SettingsData["JoystickRightButtonIndex"].as<int>();

--- a/Source/Core/Manager/ERS_ControllerManager/ControllerInputManager.h
+++ b/Source/Core/Manager/ERS_ControllerManager/ControllerInputManager.h
@@ -52,12 +52,7 @@ public:
     std::vector<ERS_STRUCT_ControllerSettings> ControllerSettings_;          /**<List of controller settings for each controller*/
     std::vector<ERS_STRUCT_ControllerSettings> AvailableControllerProfiles_; /**<List of different loaded profiles. Will try to pick based on correct one automatically*/
 
-    // TODO: add system to apply correct controller profile by name
-    // add system to write controller profiles
-    // add window to configure profiles
-    // add option to add profiles, delete them
-    // add optin to save profiles in config window
-    // add to project files, so they load with the system
+    // TODO: apply matching controller profiles by name once input remapping consumes these settings.
 
 public:
 

--- a/Source/Core/Structures/ERS_STRUCT_ControllerSettings/ControllerSettings.h
+++ b/Source/Core/Structures/ERS_STRUCT_ControllerSettings/ControllerSettings.h
@@ -20,47 +20,47 @@
 struct ERS_STRUCT_ControllerSettings {
 
     // Controller Settings Name
-    std::string SettingsProfileName; /**<Name of this profile. Shows in dropdown menu*/
-    std::string ControllerName; /**<Name of the controller to apply this profile to*/
+    std::string SettingsProfileName = "Default Layout"; /**<Name of this profile. Shows in dropdown menu*/
+    std::string ControllerName = "*"; /**<Name of the controller to apply this profile to*/
 
     // Joystick Settings
-    float MinThresholdJoystickLeftX; /**<Minimum value from joystick to be considered a value*/
-    float MinThresholdJoystickLeftY; /**<Minimum value from joystick to be considered a value*/
-    float MinThresholdJoystickRightX; /**<Minimum value from joystick to be considered a value*/
-    float MinThresholdJoystickRightY; /**<Minimum value from joystick to be considered a value*/
+    float MinThresholdJoystickLeftX = 0.0f; /**<Minimum value from joystick to be considered a value*/
+    float MinThresholdJoystickLeftY = 0.0f; /**<Minimum value from joystick to be considered a value*/
+    float MinThresholdJoystickRightX = 0.0f; /**<Minimum value from joystick to be considered a value*/
+    float MinThresholdJoystickRightY = 0.0f; /**<Minimum value from joystick to be considered a value*/
 
-    float MaxThresholdJoystickLeftX; /**<Maximum value from joystick before JS is fully on*/
-    float MaxThresholdJoystickLeftY; /**<Minimum value from joystick to be considered a value*/
-    float MaxThresholdJoystickRightX; /**<Minimum value from joystick to be considered a value*/
-    float MaxThresholdJoystickRightY; /**<Minimum value from joystick to be considered a value*/
+    float MaxThresholdJoystickLeftX = 1.0f; /**<Maximum value from joystick before JS is fully on*/
+    float MaxThresholdJoystickLeftY = 1.0f; /**<Minimum value from joystick to be considered a value*/
+    float MaxThresholdJoystickRightX = 1.0f; /**<Minimum value from joystick to be considered a value*/
+    float MaxThresholdJoystickRightY = 1.0f; /**<Minimum value from joystick to be considered a value*/
 
-    float JoystickLeftXGain; /**<Joystick Gain*/
-    float JoystickLeftYGain; /**<Joystick Gain*/
-    float JoystickRightXGain; /**<Joystick Gain*/
-    float JoystickRightYGain; /**<Joystick Gain*/
+    float JoystickLeftXGain = 1.0f; /**<Joystick Gain*/
+    float JoystickLeftYGain = 1.0f; /**<Joystick Gain*/
+    float JoystickRightXGain = 1.0f; /**<Joystick Gain*/
+    float JoystickRightYGain = 1.0f; /**<Joystick Gain*/
 
     // Trigger Settings
-    float MinThresholdTriggerLeft; /**<Minimum value from trigger to be considered valid, all values below this are discarded*/
-    float MinThresholdTriggerRight; /**<Minimum value from trigger to be considered valid, all values below this are discarded*/
+    float MinThresholdTriggerLeft = 0.0f; /**<Minimum value from trigger to be considered valid, all values below this are discarded*/
+    float MinThresholdTriggerRight = 0.0f; /**<Minimum value from trigger to be considered valid, all values below this are discarded*/
     
-    float MaxThresholdTriggerLeft; /**<Max value for trigger to be fully pressed*/
-    float MaxThresholdTriggerRight; /**<Max value for trigger to be fully pressed*/
+    float MaxThresholdTriggerLeft = 1.0f; /**<Max value for trigger to be fully pressed*/
+    float MaxThresholdTriggerRight = 1.0f; /**<Max value for trigger to be fully pressed*/
 
     // Button Remap
-    int TriangleButtonIndex; /**<Button Index*/
-    int SquareButtonIndex; /**<Button Index*/
-    int CrossButtonIndex; /**<Button Index*/
-    int CircleButtonIndex;/**<Button Index*/
-    int BackButtonIndex; /**<Button Index*/
-    int OptionsButtonIndex; /**<Button Index*/
-    int MenuButtonIndex; /**<Button Index*/
-    int JoystickRightButtonIndex; /**<Button Index*/
-    int JoystickLeftButtonIndex; /**<Button Index*/
-    int LeftBumperButtonIndex; /**<Button Index*/
-    int RightBumperButtonIndex; /**<Button Index*/
-    int DPADUpButtonIndex; /**<Button Index*/
-    int DPADDownButtonIndex; /**<Button Index*/
-    int DPADLeftButtonIndex; /**<Button Index*/
-    int DPADRightButtonIndex; /**<Button Index*/
+    int TriangleButtonIndex = 3; /**<Button Index*/
+    int SquareButtonIndex = 2; /**<Button Index*/
+    int CrossButtonIndex = 0; /**<Button Index*/
+    int CircleButtonIndex = 1;/**<Button Index*/
+    int BackButtonIndex = 6; /**<Button Index*/
+    int OptionsButtonIndex = 8; /**<Button Index*/
+    int MenuButtonIndex = 7; /**<Button Index*/
+    int JoystickRightButtonIndex = 10; /**<Button Index*/
+    int JoystickLeftButtonIndex = 9; /**<Button Index*/
+    int LeftBumperButtonIndex = 4; /**<Button Index*/
+    int RightBumperButtonIndex = 5; /**<Button Index*/
+    int DPADUpButtonIndex = 11; /**<Button Index*/
+    int DPADDownButtonIndex = 12; /**<Button Index*/
+    int DPADLeftButtonIndex = 13; /**<Button Index*/
+    int DPADRightButtonIndex = 14; /**<Button Index*/
 
 };

--- a/Source/Core/Writers/ERS_ProjectWriter/ProjectWriter.cpp
+++ b/Source/Core/Writers/ERS_ProjectWriter/ProjectWriter.cpp
@@ -5,6 +5,69 @@
 #include <ProjectWriter.h>
 
 
+namespace {
+
+unsigned long ERS_FUNCTION_GetControllerSettingsPairCount(ERS_STRUCT_Project* ProjectPointer) {
+
+    if (ProjectPointer->ControllerSettings == nullptr) {
+        return 0;
+    }
+
+    unsigned long ControllerSettingsCount = ProjectPointer->ControllerSettings->size();
+    if (ProjectPointer->GameControllerSettingsIDs.size() < ControllerSettingsCount) {
+        ControllerSettingsCount = ProjectPointer->GameControllerSettingsIDs.size();
+    }
+
+    return ControllerSettingsCount;
+
+}
+
+void ERS_FUNCTION_EmitControllerSettings(YAML::Emitter* Emitter, ERS_STRUCT_ControllerSettings* ControllerSettings) {
+
+    (*Emitter)<<YAML::BeginMap;
+    (*Emitter)<<YAML::Key<<"ControllerName"<<YAML::Value<<ControllerSettings->ControllerName;
+    (*Emitter)<<YAML::Key<<"SettingsProfileName"<<YAML::Value<<ControllerSettings->SettingsProfileName;
+
+    (*Emitter)<<YAML::Key<<"JoystickLeftXGain"<<YAML::Value<<ControllerSettings->JoystickLeftXGain;
+    (*Emitter)<<YAML::Key<<"JoystickLeftYGain"<<YAML::Value<<ControllerSettings->JoystickLeftYGain;
+    (*Emitter)<<YAML::Key<<"JoystickRightXGain"<<YAML::Value<<ControllerSettings->JoystickRightXGain;
+    (*Emitter)<<YAML::Key<<"JoystickRightYGain"<<YAML::Value<<ControllerSettings->JoystickRightYGain;
+
+    (*Emitter)<<YAML::Key<<"MinThresholdJoystickLeftX"<<YAML::Value<<ControllerSettings->MinThresholdJoystickLeftX;
+    (*Emitter)<<YAML::Key<<"MinThresholdJoystickLeftY"<<YAML::Value<<ControllerSettings->MinThresholdJoystickLeftY;
+    (*Emitter)<<YAML::Key<<"MinThresholdJoystickRightX"<<YAML::Value<<ControllerSettings->MinThresholdJoystickRightX;
+    (*Emitter)<<YAML::Key<<"MinThresholdJoystickRightY"<<YAML::Value<<ControllerSettings->MinThresholdJoystickRightY;
+    (*Emitter)<<YAML::Key<<"MaxThresholdJoystickLeftX"<<YAML::Value<<ControllerSettings->MaxThresholdJoystickLeftX;
+    (*Emitter)<<YAML::Key<<"MaxThresholdJoystickLeftY"<<YAML::Value<<ControllerSettings->MaxThresholdJoystickLeftY;
+    (*Emitter)<<YAML::Key<<"MaxThresholdJoystickRightX"<<YAML::Value<<ControllerSettings->MaxThresholdJoystickRightX;
+    (*Emitter)<<YAML::Key<<"MaxThresholdJoystickRightY"<<YAML::Value<<ControllerSettings->MaxThresholdJoystickRightY;
+
+    (*Emitter)<<YAML::Key<<"MinThresholdTriggerLeft"<<YAML::Value<<ControllerSettings->MinThresholdTriggerLeft;
+    (*Emitter)<<YAML::Key<<"MinThresholdTriggerRight"<<YAML::Value<<ControllerSettings->MinThresholdTriggerRight;
+    (*Emitter)<<YAML::Key<<"MaxThresholdTriggerLeft"<<YAML::Value<<ControllerSettings->MaxThresholdTriggerLeft;
+    (*Emitter)<<YAML::Key<<"MaxThresholdTriggerRight"<<YAML::Value<<ControllerSettings->MaxThresholdTriggerRight;
+
+    (*Emitter)<<YAML::Key<<"JoystickLeftButtonIndex"<<YAML::Value<<ControllerSettings->JoystickLeftButtonIndex;
+    (*Emitter)<<YAML::Key<<"JoystickRightButtonIndex"<<YAML::Value<<ControllerSettings->JoystickRightButtonIndex;
+    (*Emitter)<<YAML::Key<<"BackButtonIndex"<<YAML::Value<<ControllerSettings->BackButtonIndex;
+    (*Emitter)<<YAML::Key<<"MenuButtonIndex"<<YAML::Value<<ControllerSettings->MenuButtonIndex;
+    (*Emitter)<<YAML::Key<<"OptionsButtonIndex"<<YAML::Value<<ControllerSettings->OptionsButtonIndex;
+    (*Emitter)<<YAML::Key<<"TriangleButtonIndex"<<YAML::Value<<ControllerSettings->TriangleButtonIndex;
+    (*Emitter)<<YAML::Key<<"SquareButtonIndex"<<YAML::Value<<ControllerSettings->SquareButtonIndex;
+    (*Emitter)<<YAML::Key<<"CircleButtonIndex"<<YAML::Value<<ControllerSettings->CircleButtonIndex;
+    (*Emitter)<<YAML::Key<<"CrossButtonIndex"<<YAML::Value<<ControllerSettings->CrossButtonIndex;
+    (*Emitter)<<YAML::Key<<"RightBumperButtonIndex"<<YAML::Value<<ControllerSettings->RightBumperButtonIndex;
+    (*Emitter)<<YAML::Key<<"LeftBumperButtonIndex"<<YAML::Value<<ControllerSettings->LeftBumperButtonIndex;
+    (*Emitter)<<YAML::Key<<"DPADUpButtonIndex"<<YAML::Value<<ControllerSettings->DPADUpButtonIndex;
+    (*Emitter)<<YAML::Key<<"DPADDownButtonIndex"<<YAML::Value<<ControllerSettings->DPADDownButtonIndex;
+    (*Emitter)<<YAML::Key<<"DPADLeftButtonIndex"<<YAML::Value<<ControllerSettings->DPADLeftButtonIndex;
+    (*Emitter)<<YAML::Key<<"DPADRightButtonIndex"<<YAML::Value<<ControllerSettings->DPADRightButtonIndex;
+    (*Emitter)<<YAML::EndMap;
+
+}
+
+}
+
 
 ERS_CLASS_ProjectWriter::ERS_CLASS_ProjectWriter(ERS_STRUCT_SystemUtils* SystemUtils) {
 
@@ -69,6 +132,14 @@ bool ERS_CLASS_ProjectWriter::SaveProject(ERS_STRUCT_Project* ProjectPointer, lo
     ProjectEmitter<<YAML::EndMap;
     ProjectEmitter<<YAML::Key<<"DefaultLayout"<<YAML::Value<<ProjectPointer->DefaultLayout;
 
+    unsigned long ControllerSettingsCount = ERS_FUNCTION_GetControllerSettingsPairCount(ProjectPointer);
+    ProjectEmitter<<YAML::Key<<"ControllerSettings";
+    ProjectEmitter<<YAML::Key<<YAML::BeginMap;
+    for (unsigned long i = 0; i < ControllerSettingsCount; i++) {
+        ProjectEmitter<<YAML::Key<<i<<ProjectPointer->GameControllerSettingsIDs[i];
+    }
+    ProjectEmitter<<YAML::EndMap;
+
     ProjectEmitter<<YAML::Key<<"DefaultShaderProgram"<<YAML::Value<<ProjectPointer->DefaultShaderProgram;
     ProjectEmitter<<YAML::Key<<"ShaderPrograms";
     ProjectEmitter<<YAML::Key<<YAML::BeginMap;
@@ -120,6 +191,24 @@ bool ERS_CLASS_ProjectWriter::SaveProject(ERS_STRUCT_Project* ProjectPointer, lo
         ScriptData->Size_B = ProjectPointer->Scripts[i].Code_.size();
         memcpy(ScriptData->Data.get(), ProjectPointer->Scripts[i].Code_.c_str(), ProjectPointer->Scripts[i].Code_.size());
         SystemUtils_->ERS_IOSubsystem_->WriteAsset(ProjectPointer->Scripts[i].AssetID, ScriptData.get());
+
+    }
+
+    // Write Controller Settings
+    SystemUtils_->Logger_->Log("Writing Controller Settings", 4);
+    for (unsigned long i = 0; i < ControllerSettingsCount; i++) {
+
+        SystemUtils_->Logger_->Log(std::string("Writing Controller Settings '") + (*ProjectPointer->ControllerSettings)[i].SettingsProfileName + std::string("'"), 3);
+        YAML::Emitter ControllerSettingsEmitter;
+        ERS_FUNCTION_EmitControllerSettings(&ControllerSettingsEmitter, &(*ProjectPointer->ControllerSettings)[i]);
+        std::string ControllerSettingsByteString = ControllerSettingsEmitter.c_str();
+
+        std::unique_ptr<BG::ERS::IOSubsystem::IOData> ControllerSettingsData = std::make_unique<BG::ERS::IOSubsystem::IOData>();
+        ControllerSettingsData->AssetTypeName = "ControllerSettings";
+        ControllerSettingsData->Data.reset(new unsigned char[ControllerSettingsByteString.size()]);
+        ControllerSettingsData->Size_B = ControllerSettingsByteString.size();
+        memcpy(ControllerSettingsData->Data.get(), ControllerSettingsByteString.c_str(), ControllerSettingsByteString.size());
+        SystemUtils_->ERS_IOSubsystem_->WriteAsset(ProjectPointer->GameControllerSettingsIDs[i], ControllerSettingsData.get());
 
     }
 


### PR DESCRIPTION
## Summary
- serialize controller settings IDs into saved project metadata
- write each controller settings profile as its own `ControllerSettings` asset during project save
- give newly created/default controller profiles deterministic default values
- load right-stick minimum threshold from the correct YAML key and preserve optional trigger thresholds when present
- narrow the remaining controller TODO to runtime profile matching/remapping work

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `git diff --check`
- source search confirming controller settings metadata/assets are emitted and obsolete write/save TODOs are gone
- focused C++17 controller-profile defaults/pair-count probe
- clean `origin/master` patch-apply check
- `cmake -S . -B Build/ers-controller-profile-persistence-check -G "Unix Makefiles"` blocked by existing environment issue: missing `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` and no Unix Makefiles build program (`CMAKE_MAKE_PROGRAM` unset)
