### PR TITLE
Persist renderer settings in project metadata

### DIFF
--- a/Source/Core/Loader/ERS_ProjectLoader/ProjectLoader.cpp
+++ b/Source/Core/Loader/ERS_ProjectLoader/ProjectLoader.cpp
@@ -5,6 +5,97 @@
 #include <ProjectLoader.h>
 
 
+namespace {
+
+    ERS::Renderer::ShadowFilteringType LoadShadowFilteringType(int Value, ERS::Renderer::ShadowFilteringType Fallback) {
+
+        switch (Value) {
+            case ERS::Renderer::ERS_SHADOW_FILTERING_DISABLED:
+            case ERS::Renderer::ERS_SHADOW_FILTERING_PCF:
+            case ERS::Renderer::ERS_SHADOW_FILTERING_POISSON_SAMPLING:
+            case ERS::Renderer::ERS_SHADOW_FILTERING_STRATIFIED_POISSON_SAMPLING:
+                return static_cast<ERS::Renderer::ShadowFilteringType>(Value);
+            default:
+                return Fallback;
+        }
+
+    }
+
+    ERS::Renderer::ShadowUpdateMode LoadShadowUpdateMode(int Value, ERS::Renderer::ShadowUpdateMode Fallback) {
+
+        switch (Value) {
+            case ERS::Renderer::ERS_SHADOW_UPDATE_MODE_DISABLED:
+            case ERS::Renderer::ERS_SHADOW_UPDATE_MODE_RANDOM:
+            case ERS::Renderer::ERS_SHADOW_UPDATE_MODE_CONSECUTIVE:
+            case ERS::Renderer::ERS_SHADOW_UPDATE_MODE_DISTANCE_PRIORITIZED:
+            case ERS::Renderer::ERS_SHADOW_UPDATE_MODE_ALL:
+                return static_cast<ERS::Renderer::ShadowUpdateMode>(Value);
+            default:
+                return Fallback;
+        }
+
+    }
+
+    void LoadRendererSettings(const YAML::Node& RendererSettingsNode, ERS_STRUCT_RendererSettings* RendererSettings) {
+
+        if (!RendererSettingsNode || RendererSettings == nullptr) {
+            return;
+        }
+
+        if (RendererSettingsNode["ShadowMapX"]) {
+            RendererSettings->ShadowMapX_ = RendererSettingsNode["ShadowMapX"].as<int>();
+        }
+        if (RendererSettingsNode["ShadowMapY"]) {
+            RendererSettings->ShadowMapY_ = RendererSettingsNode["ShadowMapY"].as<int>();
+        }
+        if (RendererSettingsNode["ShadowFilteringType"]) {
+            RendererSettings->ShadowFilteringType_ = LoadShadowFilteringType(RendererSettingsNode["ShadowFilteringType"].as<int>(), RendererSettings->ShadowFilteringType_);
+        }
+        if (RendererSettingsNode["ShadowUpdateMode"]) {
+            RendererSettings->ShadowUpdateMode_ = LoadShadowUpdateMode(RendererSettingsNode["ShadowUpdateMode"].as<int>(), RendererSettings->ShadowUpdateMode_);
+        }
+        if (RendererSettingsNode["MaxShadowUpdatesPerFrame"]) {
+            RendererSettings->MaxShadowUpdatesPerFrame_ = RendererSettingsNode["MaxShadowUpdatesPerFrame"].as<int>();
+        }
+        if (RendererSettingsNode["ShadowFilterKernelSize"]) {
+            RendererSettings->ShadowFilterKernelSize_ = RendererSettingsNode["ShadowFilterKernelSize"].as<int>();
+        }
+        if (RendererSettingsNode["VRAMBudget"]) {
+            RendererSettings->VRAMBudget_ = RendererSettingsNode["VRAMBudget"].as<unsigned long long>();
+        }
+        if (RendererSettingsNode["RAMBudget"]) {
+            RendererSettings->RAMBudget_ = RendererSettingsNode["RAMBudget"].as<unsigned long long>();
+        }
+        if (RendererSettingsNode["WarningLowRAMBytes"]) {
+            RendererSettings->WarningLowRAMBytes = RendererSettingsNode["WarningLowRAMBytes"].as<unsigned long long>();
+        }
+        if (RendererSettingsNode["CriticalLowRAMBytes"]) {
+            RendererSettings->CriticalLowRAMBytes = RendererSettingsNode["CriticalLowRAMBytes"].as<unsigned long long>();
+        }
+        if (RendererSettingsNode["FatalLowRAMBytes"]) {
+            RendererSettings->FatalLowRAMBytes = RendererSettingsNode["FatalLowRAMBytes"].as<unsigned long long>();
+        }
+        if (RendererSettingsNode["TerminateLowRAMBytes"]) {
+            RendererSettings->TerminateLowRAMBytes = RendererSettingsNode["TerminateLowRAMBytes"].as<unsigned long long>();
+        }
+        if (RendererSettingsNode["WarningLowVRAMBytes"]) {
+            RendererSettings->WarningLowVRAMBytes = RendererSettingsNode["WarningLowVRAMBytes"].as<unsigned long long>();
+        }
+        if (RendererSettingsNode["CriticalLowVRAMBytes"]) {
+            RendererSettings->CriticalLowVRAMBytes = RendererSettingsNode["CriticalLowVRAMBytes"].as<unsigned long long>();
+        }
+        if (RendererSettingsNode["FatalLowVRAMBytes"]) {
+            RendererSettings->FatalLowVRAMBytes = RendererSettingsNode["FatalLowVRAMBytes"].as<unsigned long long>();
+        }
+        if (RendererSettingsNode["TerminateLowVRAMBytes"]) {
+            RendererSettings->TerminateLowVRAMBytes = RendererSettingsNode["TerminateLowVRAMBytes"].as<unsigned long long>();
+        }
+
+    }
+
+}
+
+
 ERS_CLASS_ProjectLoader::ERS_CLASS_ProjectLoader(ERS_STRUCT_SystemUtils* SystemUtils) {
 
     SystemUtils_ = SystemUtils;
@@ -57,6 +148,11 @@ ERS_STRUCT_Project ERS_CLASS_ProjectLoader::LoadProject(long AssetID) {
     } else {
         Project.StartPlayingOnLoad = false;
         SystemUtils_->Logger_->Log("Project Metadata Missing 'PlayOnLoad' Param, Defaulting to 'FALSE'", 7);
+    }
+
+    LoadRendererSettings(ProjectNode["RendererSettings"], &Project.RendererSettings);
+    if (SystemUtils_->RendererSettings_ != nullptr) {
+        *SystemUtils_->RendererSettings_ = Project.RendererSettings;
     }
 
 

--- a/Source/Core/Structures/ERS_STRUCT_Project/CMakeLists.txt
+++ b/Source/Core/Structures/ERS_STRUCT_Project/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(ERS_STRUCT_Project
 # Link Internal Libs
 target_link_libraries(ERS_STRUCT_Project
     ERS_STRUCT_ControllerSettings
+    ERS_STRUCT_RendererSettings
     ERS_STRUCT_ShaderProgramAssetIDs
     ERS_STRUCT_Script
     )

--- a/Source/Core/Structures/ERS_STRUCT_Project/Project.h
+++ b/Source/Core/Structures/ERS_STRUCT_Project/Project.h
@@ -12,6 +12,7 @@
 
 // Internal Libraries (BG convention: use <> instead of "")
 #include <ControllerSettings.h>
+#include <RendererSettings.h>
 #include <ShaderProgramAssetIDs.h>
 #include <Script.h>
 
@@ -38,6 +39,7 @@ struct ERS_STRUCT_Project {
     std::vector<long> GameControllerSettingsIDs; /**<Vector of layouts for game controller settings*/
     std::vector<ERS_STRUCT_ShaderProgramAssetIDs> ShaderPrograms; /**<List of Shader Program Instances*/
     std::vector<ERS_STRUCT_Script> Scripts; /**<List of scripts that are instantiated to models/lights/etc.*/
+    ERS_STRUCT_RendererSettings RendererSettings; /**<Renderer settings saved with this project*/
     long DefaultShaderProgram; /**<Set default index of the shader program*/
     std::vector<ERS_STRUCT_ControllerSettings>* ControllerSettings; /**<List of game controller settings instances*/
 

--- a/Source/Core/Structures/ERS_STRUCT_RendererSettings/RendererSettings.h
+++ b/Source/Core/Structures/ERS_STRUCT_RendererSettings/RendererSettings.h
@@ -1,6 +1,3 @@
-// ToDO: then add to project struct, then update project loader/writer with this info. Then check trello board for other related tasks like live ediitng.
-
-
 //======================================================================//
 // This file is part of the BrainGenix-ERS Environment Rendering System //
 //======================================================================//

--- a/Source/Core/Writers/ERS_ProjectWriter/ProjectWriter.cpp
+++ b/Source/Core/Writers/ERS_ProjectWriter/ProjectWriter.cpp
@@ -5,6 +5,33 @@
 #include <ProjectWriter.h>
 
 
+namespace {
+
+    void EmitRendererSettings(YAML::Emitter& ProjectEmitter, const ERS_STRUCT_RendererSettings& RendererSettings) {
+
+        ProjectEmitter<<YAML::Key<<"RendererSettings"<<YAML::Value<<YAML::BeginMap;
+        ProjectEmitter<<YAML::Key<<"ShadowMapX"<<YAML::Value<<RendererSettings.ShadowMapX_;
+        ProjectEmitter<<YAML::Key<<"ShadowMapY"<<YAML::Value<<RendererSettings.ShadowMapY_;
+        ProjectEmitter<<YAML::Key<<"ShadowFilteringType"<<YAML::Value<<static_cast<int>(RendererSettings.ShadowFilteringType_);
+        ProjectEmitter<<YAML::Key<<"ShadowUpdateMode"<<YAML::Value<<static_cast<int>(RendererSettings.ShadowUpdateMode_);
+        ProjectEmitter<<YAML::Key<<"MaxShadowUpdatesPerFrame"<<YAML::Value<<RendererSettings.MaxShadowUpdatesPerFrame_;
+        ProjectEmitter<<YAML::Key<<"ShadowFilterKernelSize"<<YAML::Value<<RendererSettings.ShadowFilterKernelSize_;
+        ProjectEmitter<<YAML::Key<<"VRAMBudget"<<YAML::Value<<RendererSettings.VRAMBudget_;
+        ProjectEmitter<<YAML::Key<<"RAMBudget"<<YAML::Value<<RendererSettings.RAMBudget_;
+        ProjectEmitter<<YAML::Key<<"WarningLowRAMBytes"<<YAML::Value<<RendererSettings.WarningLowRAMBytes;
+        ProjectEmitter<<YAML::Key<<"CriticalLowRAMBytes"<<YAML::Value<<RendererSettings.CriticalLowRAMBytes;
+        ProjectEmitter<<YAML::Key<<"FatalLowRAMBytes"<<YAML::Value<<RendererSettings.FatalLowRAMBytes;
+        ProjectEmitter<<YAML::Key<<"TerminateLowRAMBytes"<<YAML::Value<<RendererSettings.TerminateLowRAMBytes;
+        ProjectEmitter<<YAML::Key<<"WarningLowVRAMBytes"<<YAML::Value<<RendererSettings.WarningLowVRAMBytes;
+        ProjectEmitter<<YAML::Key<<"CriticalLowVRAMBytes"<<YAML::Value<<RendererSettings.CriticalLowVRAMBytes;
+        ProjectEmitter<<YAML::Key<<"FatalLowVRAMBytes"<<YAML::Value<<RendererSettings.FatalLowVRAMBytes;
+        ProjectEmitter<<YAML::Key<<"TerminateLowVRAMBytes"<<YAML::Value<<RendererSettings.TerminateLowVRAMBytes;
+        ProjectEmitter<<YAML::EndMap;
+
+    }
+
+}
+
 
 ERS_CLASS_ProjectWriter::ERS_CLASS_ProjectWriter(ERS_STRUCT_SystemUtils* SystemUtils) {
 
@@ -50,6 +77,11 @@ bool ERS_CLASS_ProjectWriter::SaveProject(ERS_STRUCT_Project* ProjectPointer, lo
     ProjectEmitter<<YAML::Key<<"ProjectLicense"<<YAML::Value<<ProjectPointer->ProjectLicense;
     ProjectEmitter<<YAML::Key<<"IsLicenseProprietary"<<YAML::Value<<ProjectPointer->IsLicenseProprietary;
     ProjectEmitter<<YAML::Key<<"PlayOnLoad"<<YAML::Value<<ProjectPointer->StartPlayingOnLoad;
+
+    if (SystemUtils_->RendererSettings_ != nullptr) {
+        ProjectPointer->RendererSettings = *SystemUtils_->RendererSettings_;
+    }
+    EmitRendererSettings(ProjectEmitter, ProjectPointer->RendererSettings);
 
 
     ProjectEmitter<<YAML::Key<<"SceneIDs";


### PR DESCRIPTION
## Summary
- persist renderer settings in project metadata under a `RendererSettings` map
- load renderer settings with backward-compatible defaults and validate enum values before applying them
- sync loaded/saved project settings with `SystemUtils_->RendererSettings_` and remove the completed renderer-settings TODO

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `git diff --check`
- focused C++17 syntax checks for `ProjectLoader.cpp` and `ProjectWriter.cpp` using local stubs for unavailable external dependencies
- clean `origin/master` patch apply with `git apply --check --whitespace=error-all`
- `cmake -S . -B /tmp/ers-renderer-settings-build` still fails at the known local checkout blocker: missing `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` and no Unix Makefiles build program (`CMAKE_MAKE_PROGRAM` unset)
