### PR TITLE
Add Asset Explorer model import action

### DIFF
--- a/Source/Core/Editor/Windows/GUI_Window_AssetExplorer/GUI_Window_AssetExplorer.cpp
+++ b/Source/Core/Editor/Windows/GUI_Window_AssetExplorer/GUI_Window_AssetExplorer.cpp
@@ -23,6 +23,30 @@ GUI_Window_AssetExplorer::~GUI_Window_AssetExplorer() {
 }
 
 
+void GUI_Window_AssetExplorer::AddModelToActiveScene(long AssetID) {
+
+    if (ProjectUtils_ == nullptr || ProjectUtils_->SceneManager_ == nullptr || ProjectUtils_->SceneLoader_ == nullptr) {
+        SystemUtils_->Logger_->Log("Could Not Add Model From Asset Explorer, Project Utils Are Not Ready", 7);
+        return;
+    }
+
+    int ActiveSceneIndex = ProjectUtils_->SceneManager_->ActiveScene_;
+    if (ActiveSceneIndex < 0 || ActiveSceneIndex >= static_cast<int>(ProjectUtils_->SceneManager_->Scenes_.size())) {
+        SystemUtils_->Logger_->Log("Could Not Add Model From Asset Explorer, Active Scene Index Is Invalid", 7);
+        return;
+    }
+
+    ERS_STRUCT_Scene* Scene = ProjectUtils_->SceneManager_->Scenes_[ActiveSceneIndex].get();
+    if (Scene == nullptr) {
+        SystemUtils_->Logger_->Log("Could Not Add Model From Asset Explorer, Active Scene Is Null", 7);
+        return;
+    }
+
+    ProjectUtils_->SceneLoader_->AddModel(Scene, AssetID);
+
+}
+
+
 void GUI_Window_AssetExplorer::Draw() {
 
     if (Enabled_) {
@@ -33,7 +57,6 @@ void GUI_Window_AssetExplorer::Draw() {
 
 
         // TODO: Add "selectables" in advanced mode which list all assetids and what they do. perhaps oculd be like this: ID (One-letter-abbreviation for what it does) or an icon if we're feeling fancy
-        // add the option to import assets from the explorer into the active scene
         // add the normal mode which only shows ers assets and has names rather than ids
         // add a system to have files/folder abstractions which enables the user to organize their assets under folders, implement drag/drop with this.
 
@@ -69,6 +92,15 @@ void GUI_Window_AssetExplorer::Draw() {
                             bool Selected = ImGui::Selectable(DisplayName.c_str(), Key == SelectedModelIndex_);
                             if (Selected) {
                                 SelectedModelIndex_ = Key;
+                            }
+
+                            if (ImGui::BeginPopupContextItem()) {
+
+                                if (ImGui::MenuItem("Add To Active Scene")) {
+                                    AddModelToActiveScene(static_cast<long>(Key));
+                                }
+
+                            ImGui::EndPopup();
                             }
 
                             // Drag+Drop Source

--- a/Source/Core/Editor/Windows/GUI_Window_AssetExplorer/GUI_Window_AssetExplorer.h
+++ b/Source/Core/Editor/Windows/GUI_Window_AssetExplorer/GUI_Window_AssetExplorer.h
@@ -40,6 +40,8 @@ private:
     unsigned long SelectedModelIndex_ = 0; /**<Index Of Selected Model*/
     unsigned long SelectedScriptIndex_ = 0; /**<Index of selected script*/
 
+    void AddModelToActiveScene(long AssetID);
+
 public:
 
     bool Enabled_ = true; /**<Is Popup Enabled*/


### PR DESCRIPTION
## Summary
- add an Asset Explorer model-row context menu action for adding that asset to the active scene
- reuse the existing `SceneLoader::AddModel` path used by Scene Tree drag/drop
- remove the completed future-work note for importing explorer assets into the active scene

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `git diff --check`
- focused C++17 syntax check for `GUI_Window_AssetExplorer.cpp` using local stubs for unavailable external dependencies
- clean `origin/master` patch apply with `git apply --check --whitespace=error-all`
- `cmake -S . -B /tmp/ers-asset-explorer-add-model-build` still fails at the known local checkout blocker: missing `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` and no Unix Makefiles build program (`CMAKE_MAKE_PROGRAM` unset)
