### PR TITLE
Initialize vertex skeletal attributes

### DIFF
--- a/Source/Core/Structures/ERS_STRUCT_Vertex/Vertex.h
+++ b/Source/Core/Structures/ERS_STRUCT_Vertex/Vertex.h
@@ -22,13 +22,13 @@
 struct ERS_STRUCT_Vertex {
 
     // Set Metadata
-    glm::vec3 Position;
-    glm::vec3 Normal;
-    glm::vec2 TexCoords;
-    glm::vec3 Tangent;
-    glm::vec3 Bitangent;
+    glm::vec3 Position = glm::vec3(0.0f);
+    glm::vec3 Normal = glm::vec3(0.0f);
+    glm::vec2 TexCoords = glm::vec2(0.0f);
+    glm::vec3 Tangent = glm::vec3(0.0f);
+    glm::vec3 Bitangent = glm::vec3(0.0f);
 
-    int BoneIDs[MAX_BONE_INFLUENCE];
-    float Weights[MAX_BONE_INFLUENCE];
+    int BoneIDs[MAX_BONE_INFLUENCE] = {0, 0, 0, 0};
+    float Weights[MAX_BONE_INFLUENCE] = {0.0f, 0.0f, 0.0f, 0.0f};
 
 };


### PR DESCRIPTION
## Summary
- initialize all `ERS_STRUCT_Vertex` fields with deterministic defaults
- ensure uploaded bone IDs and weights are neutral for static meshes until full skeletal animation support exists
- keep the broader character deformation work separate from this safety fix

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `git diff --check`
- `c++ -std=c++17 -fsyntax-only -ISource/Core/Structures/ERS_STRUCT_Vertex -IThirdParty/NonSuperBuild/glm Source/Core/Structures/ERS_STRUCT_Vertex/Vertex.h`
- focused C++17 executable probe confirming default bone IDs and weights are zeroed
- clean `origin/master` patch apply with `git apply --check --whitespace=error-all`
- `cmake -S . -B /tmp/ers-vertex-defaults-build` still fails at the known local checkout blocker: missing `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` and no Unix Makefiles build program (`CMAKE_MAKE_PROGRAM` unset)
