### PR TITLE
Remove stale texture unload TODO

### DIFF
--- a/Source/Core/Loader/ERS_ModelLoader/AssetStreamingManager.cpp
+++ b/Source/Core/Loader/ERS_ModelLoader/AssetStreamingManager.cpp
@@ -229,8 +229,6 @@ void ERS_CLASS_AssetStreamingManager::CheckHardwareLimitations(ERS_STRUCT_Scene*
 
 }
 
-// todo: create function to go through textures with high levels and unload them if under a certain ram/vram threshold
-
 std::vector<ERS_STRUCT_Model*> ERS_CLASS_AssetStreamingManager::CreateListOfModelsToLoadNextLevelToVRAM(std::map<unsigned int, int> CameraUpdatesQuota, ERS_STRUCT_Scene* Scene, std::vector<std::map<float, unsigned int>> DistancesFromCamera) {
 
     // Create Vector Containing Models Which Should Be Pushed into RAM if possible
@@ -421,6 +419,5 @@ void ERS_CLASS_AssetStreamingManager::SetCurrentScene(ERS_STRUCT_Scene* Scene) {
 void ERS_CLASS_AssetStreamingManager::SetCameraStructs(std::vector<ERS_STRUCT_Camera*> Cameras) {
     Cameras_ = Cameras;
 }
-
 
 


### PR DESCRIPTION
## Summary
- remove the stale texture-unload TODO from `AssetStreamingManager.cpp`
- keep the existing RAM/VRAM pressure path unchanged: `CheckHardwareLimitations()` lowers target texture levels and `AsyncTextureUpdater` queues unloads when current levels exceed targets

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `git diff --check`
- source search confirming the obsolete TODO is gone and the existing target-lowering/unload queue path is present
- clean `origin/master` patch apply with `git apply --check --whitespace=error-all`
