### PR TITLE
Remove stale shader uniform TODO

### DIFF
--- a/Source/Core/Structures/ERS_STRUCT_ShaderUniformData/ShaderUniformData.h
+++ b/Source/Core/Structures/ERS_STRUCT_ShaderUniformData/ShaderUniformData.h
@@ -1,6 +1,3 @@
-// ToDO: then add to project struct, then update project loader/writer with this info. Then check trello board for other related tasks like live ediitng.
-
-
 //======================================================================//
 // This file is part of the BrainGenix-ERS Environment Rendering System //
 //======================================================================//


### PR DESCRIPTION
## Summary
- remove the stale project-persistence TODO from `ShaderUniformData.h`
- leave runtime shader uniform construction unchanged; this struct is rebuilt per frame from viewport, camera, shadow, and scene-light state

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `git diff --check`
- source search confirming `ShaderUniformData` is rebuilt in `VisualRenderer::UpdateShader` from runtime render state
- clean `origin/master` patch apply with `git apply --check --whitespace=error-all`
