### PR TITLE
Remove stale project metadata TODOs

### DIFF
--- a/Source/Core/Structures/ERS_STRUCT_Script/Script.h
+++ b/Source/Core/Structures/ERS_STRUCT_Script/Script.h
@@ -1,6 +1,3 @@
-// ToDO: then add to project struct, then update project loader/writer with this info. Then check trello board for other related tasks like live ediitng.
-
-
 //======================================================================//
 // This file is part of the BrainGenix-ERS Environment Rendering System //
 //======================================================================//

--- a/Source/Core/Structures/ERS_STRUCT_ShaderProgramAssetIDs/ShaderProgramAssetIDs.h
+++ b/Source/Core/Structures/ERS_STRUCT_ShaderProgramAssetIDs/ShaderProgramAssetIDs.h
@@ -1,6 +1,3 @@
-// ToDO: then add to project struct, then update project loader/writer with this info. Then check trello board for other related tasks like live ediitng.
-
-
 //======================================================================//
 // This file is part of the BrainGenix-ERS Environment Rendering System //
 //======================================================================//


### PR DESCRIPTION
I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Summary
- remove copied stale TODOs from the script and shader-program project metadata structs
- leave project metadata behavior unchanged; current Project/ProjectLoader/ProjectWriter already persist both sections

## Verification
- git diff --check
- rg evidence check for Project.h, ProjectLoader.cpp, and ProjectWriter.cpp script/shader-program persistence
- git diff --binary origin/master -- Source/Core/Structures/ERS_STRUCT_Script/Script.h Source/Core/Structures/ERS_STRUCT_ShaderProgramAssetIDs/ShaderProgramAssetIDs.h | git apply --check --cached --whitespace=error-all