### PR TITLE
Remove stale OpenGL log item TODO

### DIFF
--- a/Source/Internal/OpenGLLoggingSystem/OpenGLLogItem.h
+++ b/Source/Internal/OpenGLLoggingSystem/OpenGLLogItem.h
@@ -1,6 +1,3 @@
-// ToDO: then add to project struct, then update project loader/writer with this info. Then check trello board for other related tasks like live ediitng.
-
-
 //======================================================================//
 // This file is part of the BrainGenix-ERS Environment Rendering System //
 //======================================================================//
@@ -18,7 +15,7 @@
 
 
 /**
- * @brief Struct containing renderer settings.
+ * @brief Struct containing one OpenGL debug log item.
  * 
  */
 struct ERS_OpenGLLogItem {


### PR DESCRIPTION
I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Summary
- remove a copied project-metadata TODO from the OpenGL debug log item struct
- correct the struct brief so it describes OpenGL debug log entries instead of renderer settings

## Verification
- git diff --check
- rg check confirming the stale TODO and copied renderer-settings brief are gone from OpenGLLogItem.h
- rg evidence check for runtime OpenGL logging ownership in OpenGLLoggingSystem and the debug menu
- git diff --binary origin/master -- Source/Internal/OpenGLLoggingSystem/OpenGLLogItem.h | git apply --check --cached --whitespace=error-all