### PR TITLE
Remove stale scene object TODO

### DIFF
--- a/Source/Core/Structures/ERS_STRUCT_SceneObject/SceneObject.h
+++ b/Source/Core/Structures/ERS_STRUCT_SceneObject/SceneObject.h
@@ -1,6 +1,3 @@
-// ToDO: then add to project struct, then update project loader/writer with this info. Then check trello board for other related tasks like live ediitng.
-
-
 //======================================================================//
 // This file is part of the BrainGenix-ERS Environment Rendering System //
 //======================================================================//


### PR DESCRIPTION
I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Summary
- remove a copied project-metadata TODO from the runtime scene-object index struct
- leave scene object indexing behavior unchanged

## Verification
- git diff --check
- rg check confirming the copied TODO is gone from SceneObject.h
- rg evidence check showing SceneObjects_ is rebuilt by Scene::IndexSceneObjects and consumed by scene tree/renderer UI
- git diff --binary origin/master -- Source/Core/Structures/ERS_STRUCT_SceneObject/SceneObject.h | git apply --check --cached --whitespace=error-all