### PR TITLE
Improve GLFW error callback diagnostics

### DIFF
--- a/Source/Core/Renderer/ERS_CLASS_RendererManager/RendererManager.cpp
+++ b/Source/Core/Renderer/ERS_CLASS_RendererManager/RendererManager.cpp
@@ -5,9 +5,9 @@
 #include <RendererManager.h>
 
 
-// FIXME! MAKE MORE CLEAN LOOKING OR SOMETHING
-void ErrorCallback(int, const char* ErrorString) {
-    std::cout<<"GLFW ERROR: " << ErrorString << std::endl;
+void ErrorCallback(int ErrorCode, const char* ErrorString) {
+    const char* Message = ErrorString != nullptr ? ErrorString : "No error message provided";
+    std::cerr<<"GLFW ERROR (" << ErrorCode << "): " << Message << std::endl;
 }
 
 


### PR DESCRIPTION
I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Summary
- remove the vague RendererManager error-callback FIXME
- include the GLFW error code in callback output
- null-guard the callback message and write diagnostics to stderr

## Verification
- git diff --check
- rg check confirming the callback cleanup and glfwSetErrorCallback wiring
- focused C++17 callback-format probe
- git diff --binary origin/master -- Source/Core/Renderer/ERS_CLASS_RendererManager/RendererManager.cpp | git apply --check --cached --whitespace=error-all
- Full ERS CMake configure remains blocked locally by the existing missing vcpkg toolchain file and missing Make generator in this checkout