### PR TITLE
Fix asset streaming model and texture indexing

### DIFF
--- a/Source/Core/Loader/ERS_ModelLoader/AssetStreamingManager.cpp
+++ b/Source/Core/Loader/ERS_ModelLoader/AssetStreamingManager.cpp
@@ -243,10 +243,10 @@ std::vector<ERS_STRUCT_Model*> ERS_CLASS_AssetStreamingManager::CreateListOfMode
         std::map<float, unsigned int> ModelDistances = DistancesFromCamera[x];
         int NumberUpdates = 0;
 
-        for (unsigned int i = 0; i < ModelDistances.size(); i++) {
+        for (auto ModelDistanceIterator = ModelDistances.begin(); ModelDistanceIterator != ModelDistances.end(); ++ModelDistanceIterator) {
 
 
-            ERS_STRUCT_Model* CurrentModel = Scene->Models[ModelDistances[i]].get();
+            ERS_STRUCT_Model* CurrentModel = Scene->Models[ModelDistanceIterator->second].get();
             if (NumberUpdates >= CameraUpdatesQuota[x]) {
                 break;
             }
@@ -291,9 +291,9 @@ std::vector<ERS_STRUCT_Model*> ERS_CLASS_AssetStreamingManager::CreateListOfMode
         std::map<float, unsigned int> ModelDistances = DistancesFromCamera[x];
         int NumberUpdates = 0;
 
-        for (unsigned int i = 0; i < ModelDistances.size(); i++) {
+        for (auto ModelDistanceIterator = ModelDistances.begin(); ModelDistanceIterator != ModelDistances.end(); ++ModelDistanceIterator) {
 
-            ERS_STRUCT_Model* CurrentModel = Scene->Models[ModelDistances[i]].get();
+            ERS_STRUCT_Model* CurrentModel = Scene->Models[ModelDistanceIterator->second].get();
             if (NumberUpdates >= CameraUpdatesQuota[x]) {
                 break;
             }
@@ -421,5 +421,4 @@ void ERS_CLASS_AssetStreamingManager::SetCurrentScene(ERS_STRUCT_Scene* Scene) {
 void ERS_CLASS_AssetStreamingManager::SetCameraStructs(std::vector<ERS_STRUCT_Camera*> Cameras) {
     Cameras_ = Cameras;
 }
-
 

--- a/Source/Core/Loader/ERS_ModelLoader/AssetStreamingManager.cpp
+++ b/Source/Core/Loader/ERS_ModelLoader/AssetStreamingManager.cpp
@@ -258,7 +258,7 @@ std::vector<ERS_STRUCT_Model*> ERS_CLASS_AssetStreamingManager::CreateListOfMode
                 // Calculate Total Texture Size For Next Level
                 int NextLevelTextureSize = 0;
                 for (unsigned int z = 0; z < CurrentModel->Textures_Loaded.size(); z++) {
-                    NextLevelTextureSize += CurrentModel->Textures_Loaded[i].TextureLevels[CurrentLevel].LevelMemorySizeBytes;
+                    NextLevelTextureSize += CurrentModel->Textures_Loaded[z].TextureLevels[CurrentLevel].LevelMemorySizeBytes;
                 }
 
                 // Check If Will Fit In Mem
@@ -305,7 +305,7 @@ std::vector<ERS_STRUCT_Model*> ERS_CLASS_AssetStreamingManager::CreateListOfMode
                 // Calculate Total Texture Size For Next Level
                 int NextLevelTextureSize = 0;
                 for (unsigned int z = 0; z < CurrentModel->Textures_Loaded.size(); z++) {
-                    NextLevelTextureSize += CurrentModel->Textures_Loaded[i].TextureLevels[CurrentLevel].LevelMemorySizeBytes;
+                    NextLevelTextureSize += CurrentModel->Textures_Loaded[z].TextureLevels[CurrentLevel].LevelMemorySizeBytes;
                 }
 
                 // Check If Will Fit In Mem
@@ -421,6 +421,5 @@ void ERS_CLASS_AssetStreamingManager::SetCurrentScene(ERS_STRUCT_Scene* Scene) {
 void ERS_CLASS_AssetStreamingManager::SetCameraStructs(std::vector<ERS_STRUCT_Camera*> Cameras) {
     Cameras_ = Cameras;
 }
-
 
 

--- a/Source/Core/Loader/ERS_ModelLoader/AssetStreamingManager.cpp
+++ b/Source/Core/Loader/ERS_ModelLoader/AssetStreamingManager.cpp
@@ -337,7 +337,7 @@ std::map<unsigned int, int> ERS_CLASS_AssetStreamingManager::CalculateCameraMaxU
     // Calculate Percentage Of Total Updates Each Camera Should Have
     std::vector<float> CameraUpdatePercentages;
     for (unsigned int i = 0; i < Cameras.size(); i++) {
-        CameraUpdatePercentages.push_back(Cameras[i]->GetStreamingPriority() / TotalCameraPriorities);
+        CameraUpdatePercentages.push_back(static_cast<float>(Cameras[i]->GetStreamingPriority()) / static_cast<float>(TotalCameraPriorities));
     }
 
     // Convert Update Percentages Into Actual Update Totals

--- a/Source/Core/Loader/ERS_ModelLoader/AssetStreamingManager.cpp
+++ b/Source/Core/Loader/ERS_ModelLoader/AssetStreamingManager.cpp
@@ -44,14 +44,14 @@ void ERS_CLASS_AssetStreamingManager::UpdateSceneStreamingQueue(ERS_STRUCT_Scene
 void ERS_CLASS_AssetStreamingManager::SortSceneModels(std::map<unsigned int, int> CameraUpdatesQuota, std::vector<std::vector<std::pair<float, unsigned int>>> DistancesFromCamera, ERS_STRUCT_Scene* Scene) {
 
     // Iterate Over All Cameras, Make Recomendations From There
-    for (unsigned int CameraIndex = 0; CameraIndex < CameraUpdatesQuota.size(); CameraIndex++) {
+    for (unsigned int CameraIndex = 0; CameraIndex < CameraUpdatesQuota.size() && CameraIndex < DistancesFromCamera.size(); CameraIndex++) {
 
         
         // Sort Models From Cameras
         unsigned int MaxCameraUpdates = CameraUpdatesQuota[CameraIndex];
         unsigned int CameraVRAMUpdates = 0;
         unsigned int CameraRAMUpdates = 0;
-        for (auto DistanceMapIterator = DistancesFromCamera[0].begin(); DistanceMapIterator != DistancesFromCamera[0].end(); ++DistanceMapIterator) {
+        for (auto DistanceMapIterator = DistancesFromCamera[CameraIndex].begin(); DistanceMapIterator != DistancesFromCamera[CameraIndex].end(); ++DistanceMapIterator) {
             
             // Get Parameters From Model Array
             float ModelDistance = DistanceMapIterator->first;
@@ -421,4 +421,3 @@ void ERS_CLASS_AssetStreamingManager::SetCurrentScene(ERS_STRUCT_Scene* Scene) {
 void ERS_CLASS_AssetStreamingManager::SetCameraStructs(std::vector<ERS_STRUCT_Camera*> Cameras) {
     Cameras_ = Cameras;
 }
-


### PR DESCRIPTION
I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Summary
- use each camera's own sorted model-distance list during asset streaming decisions instead of always reading camera 0
- compute camera update fractions with floating-point division so multi-camera quotas do not collapse to zero
- iterate model distance maps by iterator instead of integer key lookup when selecting models to promote
- fix next-level VRAM/RAM texture size summing to use the texture-loop index
- avoid wrong model picks, accidental map insertions, zeroed quotas, wrong texture-size totals, and possible out-of-range texture access during streaming budget checks

## Verification
- git diff --check
- rg check confirming no DistancesFromCamera[0], ModelDistances[i], or integer GetStreamingPriority()/TotalCameraPriorities division remains and both NextLevelTextureSize loops use Textures_Loaded[z]
- focused C++17 probes for per-camera distance indexing, camera quota fractions, distance-map iteration, and texture-size summing
- full PR patch applies cleanly to a temporary origin/master worktree with git apply --check --whitespace=error-all
- Full ERS CMake configure remains blocked locally by the existing missing vcpkg toolchain file and missing Make generator in this checkout