### PR TITLE
Handle empty mesh buffer uploads

### DIFF
--- a/Source/Core/Structures/ERS_STRUCT_Mesh/Mesh.cpp
+++ b/Source/Core/Structures/ERS_STRUCT_Mesh/Mesh.cpp
@@ -17,11 +17,11 @@ void ERS_STRUCT_Mesh::SetupMesh() {
     
     // Populate Vertex Buffer
     glBindBuffer(GL_ARRAY_BUFFER, VBO);
-    glBufferData(GL_ARRAY_BUFFER, Vertices.size() * sizeof(ERS_STRUCT_Vertex), &Vertices[0], GL_STATIC_DRAW);
+    glBufferData(GL_ARRAY_BUFFER, Vertices.size() * sizeof(ERS_STRUCT_Vertex), Vertices.empty() ? nullptr : Vertices.data(), GL_STATIC_DRAW);
 
     // Populate Element Buffer
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO);
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, Indices.size() * sizeof(unsigned int), &Indices[0], GL_STATIC_DRAW);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, Indices.size() * sizeof(unsigned int), Indices.empty() ? nullptr : Indices.data(), GL_STATIC_DRAW);
 
 
     // Set Vertex Attribute Pointers


### PR DESCRIPTION
## Summary
- pass null buffer pointers when mesh vertex or index arrays are empty
- keep normal OpenGL uploads unchanged for non-empty mesh buffers
- add a trailing newline to Mesh.cpp while touching the file

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- git diff --check
- focused C++17 empty-buffer pointer probe
- PR patch applies cleanly to a temporary origin/master worktree with git apply --check --whitespace=error-all
- cmake -S . -B /tmp/ers-empty-mesh-cmake (blocked locally: missing ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake and no Unix Makefiles build program, CMAKE_MAKE_PROGRAM unset)