### PR TITLE
Preserve CPU model and vendor fields

### DIFF
--- a/Source/Internal/HardwareInformation/HardwareInformation.cpp
+++ b/Source/Internal/HardwareInformation/HardwareInformation.cpp
@@ -31,7 +31,7 @@ ERS_HardwareInformation::ERS_HardwareInformation(BG::Common::Logger::LoggingSyst
     HardwareInfo_.Static_.CPUArchitecture = std::string(architecture_name(iware::cpu::architecture()));
     HardwareInfo_.Static_.CPUEndianness = std::string(endianness_name(iware::cpu::endianness()));
     HardwareInfo_.Static_.CPUModelName = std::string(iware::cpu::model_name());
-    HardwareInfo_.Static_.CPUModelName = std::string(iware::cpu::vendor_id());
+    HardwareInfo_.Static_.CPUVendorID = std::string(iware::cpu::vendor_id());
 
     Logger_->Log(std::string(std::string("Physical CPU Cores: ") + std::to_string(HardwareInfo_.Static_.CPUPhysicalCores)).c_str(), 4);
     Logger_->Log(std::string(std::string("Logical CPU Cores: ") + std::to_string(HardwareInfo_.Static_.CPULogicalCores)).c_str(), 4);


### PR DESCRIPTION
## Summary
- store iware CPU vendor data in `CPUVendorID` instead of overwriting `CPUModelName`
- keep the CPU model name available for logging and hardware info consumers

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- git diff --check
- source search confirms `CPUVendorID` receives `iware::cpu::vendor_id()`
- focused C++17 assignment probe preserving model and vendor fields
- PR patch applies cleanly to a temporary origin/master worktree with git apply --check --whitespace=error-all
- cmake -S . -B /tmp/ers-cpu-vendor-cmake (blocked locally: missing ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake and no Unix Makefiles build program, CMAKE_MAKE_PROGRAM unset)