### PR TITLE
Seed dynamic hardware info before thread start

### DIFF
--- a/Source/Internal/HardwareInformation/HardwareInformation.cpp
+++ b/Source/Internal/HardwareInformation/HardwareInformation.cpp
@@ -102,6 +102,9 @@ ERS_HardwareInformation::ERS_HardwareInformation(BG::Common::Logger::LoggingSyst
     // Calculate Dynamic Info Refresh Rate Var
     DynamicInfoRefreshRate_ = (1 / UpdatesPerSecond) * 1000.0f;
 
+    // Populate dynamic hardware fields before other systems read them.
+    GetDynamicInformation();
+
     // Launch Thread
     Logger_->Log("Starting Dynamic Information Update Thread", 5);
     DynamicUpdateThread_ = SpawnThread();


### PR DESCRIPTION
## Summary
- refresh dynamic memory information once during hardware-info construction
- ensure immediate `GetHWInfo()` consumers see populated physical/swap memory fields before the background updater is scheduled

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- git diff --check
- source search confirms the initial `GetDynamicInformation()` call happens before starting the dynamic update thread
- focused C++17 construction-order probe
- PR patch applies cleanly to a temporary origin/master worktree with git apply --check --whitespace=error-all
- cmake -S . -B /tmp/ers-initial-dynamic-cmake (blocked locally: missing ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake and no Unix Makefiles build program, CMAKE_MAKE_PROGRAM unset)