### PR TITLE
Guard hardware info thread state

### DIFF
--- a/Source/Internal/HardwareInformation/HardwareInformation.cpp
+++ b/Source/Internal/HardwareInformation/HardwareInformation.cpp
@@ -115,7 +115,7 @@ ERS_HardwareInformation::~ERS_HardwareInformation() {
 
     // Shut Down Dynamic Update Thread
     Logger_->Log("Stopping Dynamic Update Thread", 5);
-    ShouldDynamicInfoThreadRun_ = false;
+    ShouldDynamicInfoThreadRun_.store(false);
 	if (DynamicUpdateThread_.joinable()) {
 		// Wait for the thread to finish for up to 10 seconds
 		for (int i = 0; i < 100 && DynamicUpdateThread_.joinable(); ++i) {
@@ -147,6 +147,7 @@ std::thread ERS_HardwareInformation::SpawnThread() {
 }
 
 ERS_STRUCT_HardwareInfo ERS_HardwareInformation::GetHWInfo() {
+    std::lock_guard<std::mutex> Lock(HardwareInfoMutex_);
     return HardwareInfo_;
 }
 
@@ -155,7 +156,7 @@ void ERS_HardwareInformation::DynamicInformationThread() {
     // Name Thread
     SetThreadName("SysInfo");
 
-    while (ShouldDynamicInfoThreadRun_) {
+    while (ShouldDynamicInfoThreadRun_.load()) {
 
         // Get Dynamic Info
         GetDynamicInformation();
@@ -171,6 +172,8 @@ void ERS_HardwareInformation::GetDynamicInformation() {
 
     // Get Memory Info
     const auto MemoryInfo = iware::system::memory();
+
+    std::lock_guard<std::mutex> Lock(HardwareInfoMutex_);
     HardwareInfo_.Dynamic_.PhysicalMemoryCapacity = MemoryInfo.physical_total;
     HardwareInfo_.Dynamic_.PhysicalMemoryFree = MemoryInfo.physical_available;
     HardwareInfo_.Dynamic_.SwapCapacity = MemoryInfo.virtual_total;

--- a/Source/Internal/HardwareInformation/HardwareInformation.h
+++ b/Source/Internal/HardwareInformation/HardwareInformation.h
@@ -1,6 +1,10 @@
 #pragma once
 
 // Standard Libraries (BG convention: use <> instead of "")
+// cppcheck-suppress missingIncludeSystem
+#include <atomic>
+// cppcheck-suppress missingIncludeSystem
+#include <mutex>
 #include <thread>
 #include <chrono>
 
@@ -31,6 +35,7 @@ class ERS_HardwareInformation {
         // Class Instances
         BG::Common::Logger::LoggingSystem* Logger_; /**<Instance Of Logging System*/
         ERS_STRUCT_HardwareInfo HardwareInfo_; /**<Internal Hardware Information Struct*/
+        std::mutex HardwareInfoMutex_; /**<Guards access to hardware info shared with the update thread*/
 
         // Config
         YAML::Node SystemConfiguration_; /**MSystem Configuration*/
@@ -49,7 +54,7 @@ class ERS_HardwareInformation {
 
         // Control Vars
         float DynamicInfoRefreshRate_; /*<Set Number Of ms To wait until next dynamic info refresh*/
-        bool ShouldDynamicInfoThreadRun_ = true; /**<Control Variable For Dynamic Info Thread*/
+        std::atomic_bool ShouldDynamicInfoThreadRun_ = true; /**<Control Variable For Dynamic Info Thread*/
 
         std::thread DynamicUpdateThread_; /**<Dynamic Update Thread*/
 


### PR DESCRIPTION
## Summary
- protect `HardwareInfo_` copies and dynamic-memory updates with a mutex
- use an atomic stop flag for the dynamic hardware information thread
- add targeted Cppcheck suppressions for the new standard-library includes

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- git diff --check
- source search confirms `HardwareInfoMutex_`, `std::atomic_bool`, and lock/store/load usage
- focused C++17 threaded snapshot/update probe
- PR patch applies cleanly to a temporary origin/master worktree with git apply --check --whitespace=error-all
- cmake -S . -B /tmp/ers-hwinfo-thread-cmake (blocked locally: missing ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake and no Unix Makefiles build program, CMAKE_MAKE_PROGRAM unset)