### PR TITLE
Guard mesh loader optional data

### DIFF
--- a/Source/Core/Loader/ERS_ModelLoader/ModelLoader.cpp
+++ b/Source/Core/Loader/ERS_ModelLoader/ModelLoader.cpp
@@ -512,6 +512,10 @@ ERS_STRUCT_Mesh ERS_CLASS_ModelLoader::ProcessMesh(ERS_STRUCT_Model* Model, unsi
         // Hold Vertex Data
         ERS_STRUCT_Vertex Vertex;
         glm::vec3 Vector;
+        Vertex.Normal = glm::vec3(0.0f);
+        Vertex.TexCoords = glm::vec2(0.0f, 0.0f);
+        Vertex.Tangent = glm::vec3(0.0f);
+        Vertex.Bitangent = glm::vec3(0.0f);
 
 
         Vector.x = Mesh->mVertices[i].x;
@@ -535,7 +539,9 @@ ERS_STRUCT_Mesh ERS_CLASS_ModelLoader::ProcessMesh(ERS_STRUCT_Model* Model, unsi
             Vec.x = Mesh->mTextureCoords[0][i].x;
             Vec.y = Mesh->mTextureCoords[0][i].y;
             Vertex.TexCoords = Vec;
+        }
 
+        if (Mesh->HasTangentsAndBitangents()) {
             // Tangent
             Vector.x = Mesh->mTangents[i].x;
             Vector.y = Mesh->mTangents[i].y;
@@ -547,9 +553,6 @@ ERS_STRUCT_Mesh ERS_CLASS_ModelLoader::ProcessMesh(ERS_STRUCT_Model* Model, unsi
             Vector.y = Mesh->mBitangents[i].y;
             Vector.z = Mesh->mBitangents[i].z;
             Vertex.Bitangent = Vector;
-
-        } else {
-            Vertex.TexCoords = glm::vec2(0.0f, 0.0f);
         }
 
         OutputMesh.Vertices.push_back(Vertex);
@@ -644,4 +647,3 @@ void ERS_CLASS_ModelLoader::IdentifyMeshTextures(aiMaterial* Mat, ERS_STRUCT_Mes
     }
 
 }
-

--- a/Source/Core/Loader/ERS_ModelLoader/ModelLoader.cpp
+++ b/Source/Core/Loader/ERS_ModelLoader/ModelLoader.cpp
@@ -499,7 +499,10 @@ ERS_STRUCT_Mesh ERS_CLASS_ModelLoader::ProcessMesh(ERS_STRUCT_Model* Model, unsi
 
     // Create Data Holders
     ERS_STRUCT_Mesh OutputMesh;
-    OutputMesh = Model->Meshes[Model->NumMeshes_];
+    bool HasMetadataMeshSlot = Model->NumMeshes_ < (int)Model->Meshes.size();
+    if (HasMetadataMeshSlot) {
+        OutputMesh = Model->Meshes[Model->NumMeshes_];
+    }
 
 
 
@@ -578,7 +581,11 @@ ERS_STRUCT_Mesh ERS_CLASS_ModelLoader::ProcessMesh(ERS_STRUCT_Model* Model, unsi
 
 
     // Return Populated Mesh
-    Model->Meshes[Model->NumMeshes_] = OutputMesh;
+    if (HasMetadataMeshSlot) {
+        Model->Meshes[Model->NumMeshes_] = OutputMesh;
+    } else {
+        Model->Meshes.push_back(OutputMesh);
+    }
     Model->NumMeshes_++;
 
     return OutputMesh;

--- a/Source/Internal/ExternalModelLoader/ExternalModelLoader.cpp
+++ b/Source/Internal/ExternalModelLoader/ExternalModelLoader.cpp
@@ -406,6 +406,10 @@ ERS_STRUCT_Mesh ExternalModelLoader::ProcessMesh(ERS_STRUCT_ModelWriterData &Dat
         // Hold Vertex Data
         ERS_STRUCT_Vertex Vertex;
         glm::vec3 Vector;
+        Vertex.Normal = glm::vec3(0.0f);
+        Vertex.TexCoords = glm::vec2(0.0f, 0.0f);
+        Vertex.Tangent = glm::vec3(0.0f);
+        Vertex.Bitangent = glm::vec3(0.0f);
 
 
         Vector.x = Mesh->mVertices[i].x;
@@ -429,7 +433,9 @@ ERS_STRUCT_Mesh ExternalModelLoader::ProcessMesh(ERS_STRUCT_ModelWriterData &Dat
             Vec.x = Mesh->mTextureCoords[0][i].x;
             Vec.y = Mesh->mTextureCoords[0][i].y;
             Vertex.TexCoords = Vec;
+        }
 
+        if (Mesh->HasTangentsAndBitangents()) {
             // Tangent
             Vector.x = Mesh->mTangents[i].x;
             Vector.y = Mesh->mTangents[i].y;
@@ -441,9 +447,6 @@ ERS_STRUCT_Mesh ExternalModelLoader::ProcessMesh(ERS_STRUCT_ModelWriterData &Dat
             Vector.y = Mesh->mBitangents[i].y;
             Vector.z = Mesh->mBitangents[i].z;
             Vertex.Bitangent = Vector;
-
-        } else {
-            Vertex.TexCoords = glm::vec2(0.0f, 0.0f);
         }
 
         OutputMesh.Vertices.push_back(Vertex);


### PR DESCRIPTION
## Summary
- initialize optional per-vertex normal/UV/tangent attributes before reading Assimp mesh data
- read `mTangents` and `mBitangents` only when `HasTangentsAndBitangents()` is true
- preserve existing mesh metadata slots when present and append a mesh slot if metadata is missing
- apply the optional tangent guard to runtime model loading and external model import

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- git diff --check
- source search confirms tangent reads are guarded by `HasTangentsAndBitangents()` and missing metadata slots append safely
- focused C++17 optional tangent/default attribute probe
- focused C++17 metadata mesh-slot preservation/append probe
- PR patch applies cleanly to a temporary origin/master worktree with git apply --check --whitespace=error-all
- cmake -S . -B /tmp/ers-loader-safety-cmake (blocked locally: missing ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake and no Unix Makefiles build program, CMAKE_MAKE_PROGRAM unset)