### PR TITLE
Ensure at least one model loader worker

### DIFF
--- a/Source/Core/Loader/ERS_ModelLoader/ModelLoader.cpp
+++ b/Source/Core/Loader/ERS_ModelLoader/ModelLoader.cpp
@@ -23,8 +23,12 @@ ERS_CLASS_ModelLoader::ERS_CLASS_ModelLoader(ERS_STRUCT_SystemUtils* SystemUtils
 
     if (MaxModelLoadingThreads == -1) {
         SystemUtils_->Logger_->Log("Identifying Number Of CPU Cores", 4);
-        MaxModelLoadingThreads = std::thread::hardware_concurrency();
+        unsigned int DetectedHardwareThreads = std::thread::hardware_concurrency();
+        MaxModelLoadingThreads = DetectedHardwareThreads == 0 ? 1 : (int)DetectedHardwareThreads;
         SystemUtils_->Logger_->Log(std::string(std::string("Identified ") + std::to_string(MaxModelLoadingThreads) + std::string(" Cores")).c_str(), 4);
+    }
+    if (MaxModelLoadingThreads < 1) {
+        MaxModelLoadingThreads = 1;
     }
     SystemUtils_->Logger_->Log(std::string(std::string("Creating ") + std::to_string(MaxModelLoadingThreads) + std::string("Model Loading Threads")).c_str(), 4);
     for (int i = 0; i < MaxModelLoadingThreads; i++) {
@@ -644,4 +648,3 @@ void ERS_CLASS_ModelLoader::IdentifyMeshTextures(aiMaterial* Mat, ERS_STRUCT_Mes
     }
 
 }
-


### PR DESCRIPTION
## Summary
- handle `std::thread::hardware_concurrency()` returning 0 when auto-detecting model loader workers
- clamp nonpositive configured worker counts to one worker so queued model loads can still run

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- git diff --check
- source search confirms the hardware-concurrency fallback and worker-count clamp
- focused C++17 worker-count resolution probe
- PR patch applies cleanly to a temporary origin/master worktree with git apply --check --whitespace=error-all
- cmake -S . -B /tmp/ers-loader-worker-fallback-cmake (blocked locally: missing ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake and no Unix Makefiles build program, CMAKE_MAKE_PROGRAM unset)