### PR TITLE
Clamp texture worker counts

### DIFF
--- a/Source/Core/Editor/Windows/GUI_Window_AssetStreamingSettings/GUI_Window_AssetStreamingSettings.cpp
+++ b/Source/Core/Editor/Windows/GUI_Window_AssetStreamingSettings/GUI_Window_AssetStreamingSettings.cpp
@@ -23,7 +23,8 @@ GUI_Window_AssetStreamingSettings::GUI_Window_AssetStreamingSettings(ERS_STRUCT_
     VRAMWarningMiB_ = SystemUtils_->RendererSettings_->WarningLowVRAMBytes / 1048576;
     RAMWarningMiB_  = SystemUtils_->RendererSettings_->WarningLowRAMBytes  / 1048576;
 
-    MaxThreads_ = std::thread::hardware_concurrency();
+    unsigned int DetectedHardwareThreads = std::thread::hardware_concurrency();
+    MaxThreads_ = DetectedHardwareThreads == 0 ? 1 : (int)DetectedHardwareThreads;
 
 }
 

--- a/Source/Core/Loader/ERS_ModelLoader/AsyncTextureUpdater.cpp
+++ b/Source/Core/Loader/ERS_ModelLoader/AsyncTextureUpdater.cpp
@@ -13,23 +13,26 @@ ERS_CLASS_AsyncTextureUpdater::ERS_CLASS_AsyncTextureUpdater(ERS_STRUCT_SystemUt
     SystemUtils_->Logger_->Log("Initializing Automatic Texture Loading Subsystem", 5);
 
     // If Threads Is Left To Autodetect, Use That
+    int TargetLoaderThreads = (int)Threads;
     if (Threads <= 0) {
 
         // Check If Config Has Param
         if ((*SystemUtils_->LocalSystemConfiguration_)["TextureLoaderThreadCount"]) {
             SystemUtils_->Logger_->Log("Using Config File To Set Number Of Texture Loader Threads", 4);
-            Threads = (*SystemUtils_->LocalSystemConfiguration_)["TextureLoaderThreadCount"].as<int>();
+            TargetLoaderThreads = (*SystemUtils_->LocalSystemConfiguration_)["TextureLoaderThreadCount"].as<int>();
         } else {
             SystemUtils_->Logger_->Log("Autodetecting Number Of Threads To Use", 4);
-            Threads = std::thread::hardware_concurrency() - 2;
-            if (Threads < 2) {
-                Threads = 2;
+            unsigned int DetectedHardwareThreads = std::thread::hardware_concurrency();
+            if (DetectedHardwareThreads <= 2) {
+                TargetLoaderThreads = 2;
                 SystemUtils_->Logger_->Log("Less Than Two CPUs Detected, Will Use Two Threads Regardless, However Frame Drops May Happen", 6);
+            } else {
+                TargetLoaderThreads = (int)DetectedHardwareThreads - 2;
             }
         }
     }
 
-    SetNumLoaderThreads(Threads);
+    SetNumLoaderThreads(TargetLoaderThreads);
     SetNumStreamerThreads(1);
     SetupPusherThreads();
     SetupLoaderThreads();
@@ -843,10 +846,10 @@ int ERS_CLASS_AsyncTextureUpdater::GetNumStreamerThreads() {
     return NumPusherThreads_;
 }
 void ERS_CLASS_AsyncTextureUpdater::SetNumLoaderThreads(int NumThreads) {
-    NumLoaderThreads_ = NumThreads;
+    NumLoaderThreads_ = NumThreads < 1 ? 1 : NumThreads;
 }
 void ERS_CLASS_AsyncTextureUpdater::SetNumStreamerThreads(int NumThreads) {
-    NumPusherThreads_ = NumThreads;
+    NumPusherThreads_ = NumThreads < 1 ? 1 : NumThreads;
 }
 void ERS_CLASS_AsyncTextureUpdater::SetupPusherThreads() {
 


### PR DESCRIPTION
## Summary
- avoid unsigned underflow when autodetecting texture loader workers from `hardware_concurrency()`
- clamp texture loader and streamer worker setters to at least one thread
- keep the asset streaming settings slider max valid when hardware concurrency is unknown

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- git diff --check
- source search confirms autodetect fallback, setter clamps, and slider max fallback
- focused C++17 texture worker-count clamp probe
- PR patch applies cleanly to a temporary origin/master worktree with git apply --check --whitespace=error-all
- cmake -S . -B /tmp/ers-texture-worker-clamps-cmake (blocked locally: missing ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake and no Unix Makefiles build program, CMAKE_MAKE_PROGRAM unset)