### PR TITLE
Bind material textures during mesh draw

### DIFF
--- a/Source/Core/Renderer/ERS_CLASS_VisualRenderer/DrawMesh.cpp
+++ b/Source/Core/Renderer/ERS_CLASS_VisualRenderer/DrawMesh.cpp
@@ -9,37 +9,66 @@ void ERS_FUNCTION_DrawMesh(ERS_STRUCT_Mesh* Mesh, ERS_STRUCT_OpenGLDefaults* Ope
 
     Shader->SetMat4("model", Mesh->ModelMatrix);
 
+    unsigned int AmbientHandle = 1;
     unsigned int AmbientOcclusionHandle = 1;
+    unsigned int BaseColorHandle = 1;
     unsigned int DiffuseHandle = 1;
+    unsigned int DiffuseRoughnessHandle = 1;
     unsigned int DisplacementHandle = 1;
+    unsigned int EmissionColorHandle = 1;
     unsigned int EmissiveHandle = 1;
+    unsigned int HeightHandle = 1;
+    unsigned int LightmapHandle = 1;
     unsigned int MetalnessHandle = 1;
+    unsigned int NormalCameraHandle = 1;
     unsigned int NormalsHandle = 1;
+    unsigned int OpacityHandle = 1;
+    unsigned int ReflectionHandle = 1;
     unsigned int ShininessHandle = 1;
+    unsigned int SpecularHandle = 1;
 
 
 
     // Reset All Textures To Defaults
     unsigned int ShaderProgram = Shader->ShaderProgram_;
     unsigned int ResetTexID = OpenGLDefaults->DefaultTexture_;
+    ERS_FUNCTION_ResetMeshTexture("texture_ambient1", 0, ShaderProgram, ResetTexID);
     ERS_FUNCTION_ResetMeshTexture("texture_ambient_occlusion1", 1, ShaderProgram, ResetTexID);
+    ERS_FUNCTION_ResetMeshTexture("texture_base_color1", 2, ShaderProgram, ResetTexID);
     ERS_FUNCTION_ResetMeshTexture("texture_diffuse1", 2, ShaderProgram, ResetTexID);
     ERS_FUNCTION_ResetMeshTexture("texture_displacement1", 3, ShaderProgram, ResetTexID);
+    ERS_FUNCTION_ResetMeshTexture("texture_emission_color1", 4, ShaderProgram, ResetTexID);
     ERS_FUNCTION_ResetMeshTexture("texture_emissive1", 4, ShaderProgram, ResetTexID);
     ERS_FUNCTION_ResetMeshTexture("texture_metalness1", 5, ShaderProgram, ResetTexID);
+    ERS_FUNCTION_ResetMeshTexture("texture_normal_camera1", 6, ShaderProgram, ResetTexID);
     ERS_FUNCTION_ResetMeshTexture("texture_normals1", 6, ShaderProgram, ResetTexID);
     ERS_FUNCTION_ResetMeshTexture("texture_shininess1", 7, ShaderProgram, ResetTexID);
+    ERS_FUNCTION_ResetMeshTexture("texture_height1", 8, ShaderProgram, ResetTexID);
+    ERS_FUNCTION_ResetMeshTexture("texture_diffuse_roughness1", 9, ShaderProgram, ResetTexID);
+    ERS_FUNCTION_ResetMeshTexture("texture_lightmap1", 10, ShaderProgram, ResetTexID);
+    ERS_FUNCTION_ResetMeshTexture("texture_opacity1", 11, ShaderProgram, ResetTexID);
+    ERS_FUNCTION_ResetMeshTexture("texture_reflection1", 12, ShaderProgram, ResetTexID);
+    ERS_FUNCTION_ResetMeshTexture("texture_specular1", 13, ShaderProgram, ResetTexID);
 
 
 
+    bool HasAmbient = false;
     bool HasAmbientOcclusion = false;
+    bool HasBaseColor = false;
     bool HasDiffuse = false;
+    bool HasDiffuseRoughness = false;
     bool HasDisplacement = false;
+    bool HasEmissionColor = false;
     bool HasEmissive = false;
     bool HasHeight = false;
+    bool HasLightmap = false;
     bool HasMetalness = false;
+    bool HasNormalCamera = false;
     bool HasNormals = false;
+    bool HasOpacity = false;
+    bool HasReflection = false;
     bool HasShininess = false;
+    bool HasSpecular = false;
 
 
     // Iterate Through Textures
@@ -51,40 +80,91 @@ void ERS_FUNCTION_DrawMesh(ERS_STRUCT_Mesh* Mesh, ERS_STRUCT_OpenGLDefaults* Ope
         // Get Texture Type ID
         std::string Number;
         std::string Type = Mesh->Textures_[i]->Type;
-        int TypeID = 0;
+        int TypeID = -1;
 
         // Detect Type
-        if(Type == "texture_ambient_occlusion") {
+        if(Type == "texture_ambient") {
+            Number = std::to_string(AmbientHandle++);
+            TypeID = 0;
+            HasAmbient = true;
+        } else if(Type == "texture_ambient_occlusion") {
             Number = std::to_string(AmbientOcclusionHandle++);
             TypeID = 1;
             HasAmbientOcclusion = true;
-        } else if(Type == "texture_diffuse" || Type == "texture_base_color") {
+        } else if(Type == "texture_base_color") {
+            Number = std::to_string(BaseColorHandle++);
+            TypeID = 2;
+            HasBaseColor = true;
+            HasDiffuse = true;
+        } else if(Type == "texture_diffuse") {
             Number = std::to_string(DiffuseHandle++);
             TypeID = 2;
             HasDiffuse = true;
+        } else if(Type == "texture_diffuse_roughness") {
+            Number = std::to_string(DiffuseRoughnessHandle++);
+            TypeID = 9;
+            HasDiffuseRoughness = true;
         } else if(Type == "texture_displacement") {
             Number = std::to_string(DisplacementHandle++);
             TypeID = 3;
             HasDisplacement = true;
+        } else if(Type == "texture_emission_color") {
+            Number = std::to_string(EmissionColorHandle++);
+            TypeID = 4;
+            HasEmissionColor = true;
+            HasEmissive = true;
         } else if(Type == "texture_emissive") {
             Number = std::to_string(EmissiveHandle++);
             TypeID = 4;
             HasEmissive = true;
+        } else if(Type == "texture_height") {
+            Number = std::to_string(HeightHandle++);
+            TypeID = 8;
+            HasHeight = true;
+        } else if(Type == "texture_lightmap") {
+            Number = std::to_string(LightmapHandle++);
+            TypeID = 10;
+            HasLightmap = true;
         } else if(Type == "texture_metalness") {
             Number = std::to_string(MetalnessHandle++);
             TypeID = 5;
             HasMetalness = true;
+        } else if(Type == "texture_normal_camera") {
+            Number = std::to_string(NormalCameraHandle++);
+            TypeID = 6;
+            HasNormalCamera = true;
         } else if(Type == "texture_normals") {
             Number = std::to_string(NormalsHandle++);
             TypeID = 6;
             HasNormals = true;
+        } else if(Type == "texture_opacity") {
+            Number = std::to_string(OpacityHandle++);
+            TypeID = 11;
+            HasOpacity = true;
+        } else if(Type == "texture_reflection") {
+            Number = std::to_string(ReflectionHandle++);
+            TypeID = 12;
+            HasReflection = true;
         } else if(Type == "texture_shininess") {
             Number = std::to_string(ShininessHandle++);
             TypeID = 7;
             HasShininess = true;
+        } else if(Type == "texture_specular") {
+            Number = std::to_string(SpecularHandle++);
+            TypeID = 13;
+            HasSpecular = true;
+        }
+
+        if (TypeID < 0) {
+            continue;
         }
 
         glUniform1i(glGetUniformLocation(Shader->ShaderProgram_, (Type + Number).c_str()), TypeID);
+        if (Type == "texture_base_color") {
+            glUniform1i(glGetUniformLocation(Shader->ShaderProgram_, (std::string("texture_diffuse") + Number).c_str()), TypeID);
+        } else if (Type == "texture_emission_color") {
+            glUniform1i(glGetUniformLocation(Shader->ShaderProgram_, (std::string("texture_emissive") + Number).c_str()), TypeID);
+        }
 
         // Check If Texture Has Any Levels
         if (Mesh->Textures_[i]->HasAnyLevelReady) {
@@ -105,14 +185,23 @@ void ERS_FUNCTION_DrawMesh(ERS_STRUCT_Mesh* Mesh, ERS_STRUCT_OpenGLDefaults* Ope
     }
 
     // Set Uniforms
+    Shader->SetBool("HasAmbient", HasAmbient);
     Shader->SetBool("HasAmbientOcclusion", HasAmbientOcclusion);
+    Shader->SetBool("HasBaseColor", HasBaseColor);
     Shader->SetBool("HasDiffuse", HasDiffuse);
+    Shader->SetBool("HasDiffuseRoughness", HasDiffuseRoughness);
     Shader->SetBool("HasDisplacement", HasDisplacement);
+    Shader->SetBool("HasEmissionColor", HasEmissionColor);
     Shader->SetBool("HasEmissive", HasEmissive);
     Shader->SetBool("HasHeight", HasHeight);
+    Shader->SetBool("HasLightmap", HasLightmap);
     Shader->SetBool("HasMetalness", HasMetalness);
+    Shader->SetBool("HasNormalCamera", HasNormalCamera);
     Shader->SetBool("HasNormals", HasNormals);
+    Shader->SetBool("HasOpacity", HasOpacity);
+    Shader->SetBool("HasReflection", HasReflection);
     Shader->SetBool("HasShininess", HasShininess);
+    Shader->SetBool("HasSpecular", HasSpecular);
 
     // Shadow Control Uniforms
     Shader->SetBool("CastDynamicShadows_", *Mesh->CastDynamicShadows_);


### PR DESCRIPTION
I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Summary
- bind every imported, shader-exposed material texture type that `DrawMesh.cpp` previously skipped: ambient, base color, diffuse roughness, emission color, height, lightmap, normal camera, opacity, reflection, and specular
- set the matching `Has*` shader flags for those material texture types
- keep base-color maps available to the existing diffuse shader path and emission-color maps available to the existing emissive shader path
- ignore unsupported `texture_none` / `texture_unknown` entries instead of binding them to texture unit 0

## Context
This closes the remaining material texture binding gaps around #160. The loaders already import these Assimp texture types and shader assets/templates already expose the samplers and `Has*` flags, but the active mesh draw path only bound a smaller subset.

## Verification
- `git diff --check`
- mechanical source comparison confirming all shader-exposed imported texture types are now handled by `DrawMesh.cpp` except intentional `texture_none` / `texture_unknown`
- focused C++17 syntax check for `DrawMesh.cpp` with local OpenGL/renderer stubs
- focused C++17 executable probe exercising the real `DrawMesh.cpp` with OpenGL stubs and confirming reset/bind/flag behavior for ambient, base color, emission color, height, specular, and unknown texture entries
- clean full-branch patch apply against a temporary `origin/master` worktree

Local full CMake configure still cannot start in this ERS checkout because `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` is missing and CMake cannot find a Unix Makefiles build program (`CMAKE_MAKE_PROGRAM` is unset).
