### PR TITLE
Restore editor camera after play mode

### DIFF
--- a/Source/Core/Renderer/ERS_CLASS_VisualRenderer/VisualRenderer.cpp
+++ b/Source/Core/Renderer/ERS_CLASS_VisualRenderer/VisualRenderer.cpp
@@ -204,13 +204,61 @@ void ERS_CLASS_VisualRenderer::SetOpenGLDefaults(ERS_STRUCT_OpenGLDefaults* Defa
 
 }
 
+void ERS_CLASS_VisualRenderer::StoreEditorViewportCameraState() {
+
+    if (Viewports_.empty() || (Viewports_[0]->Camera == nullptr)) {
+        return;
+    }
+
+    ERS_STRUCT_Camera* Camera = Viewports_[0]->Camera.get();
+    StoredEditorCameraPosition_ = Camera->GetPosition();
+    StoredEditorCameraRotation_ = Camera->GetRotation();
+    StoredEditorCameraFOV_ = Camera->GetFOV();
+    Camera->GetClipBoundires(StoredEditorCameraNearClip_, StoredEditorCameraFarClip_);
+    StoredEditorCameraPriority_ = Camera->GetStreamingPriority();
+    HasStoredEditorCameraState_ = true;
+
+}
+
+void ERS_CLASS_VisualRenderer::RestoreEditorViewportCameraState() {
+
+    if (!HasStoredEditorCameraState_ || Viewports_.empty() || (Viewports_[0]->Camera == nullptr)) {
+        return;
+    }
+
+    ERS_STRUCT_Camera* Camera = Viewports_[0]->Camera.get();
+    Camera->SetPosition(StoredEditorCameraPosition_);
+    Camera->SetRotation(StoredEditorCameraRotation_);
+    Camera->SetFOV(StoredEditorCameraFOV_);
+    Camera->SetClipBoundries(StoredEditorCameraNearClip_, StoredEditorCameraFarClip_);
+    Camera->SetStreamingPriority(StoredEditorCameraPriority_);
+    Camera->Update();
+
+    if (Viewports_[0]->Processor != nullptr) {
+        Viewports_[0]->Processor->SetPosition(StoredEditorCameraPosition_);
+        Viewports_[0]->Processor->SetRotation(StoredEditorCameraRotation_);
+        Viewports_[0]->Processor->SetFOV(StoredEditorCameraFOV_);
+        Viewports_[0]->Processor->SetClipBoundries(StoredEditorCameraNearClip_, StoredEditorCameraFarClip_);
+        Viewports_[0]->Processor->SetForceUpdate();
+    }
+
+}
+
 void ERS_CLASS_VisualRenderer::UpdateViewports(float DeltaTime, ERS_CLASS_SceneManager* SceneManager) {
 
     
 
-    // Apply Scene Camera Transforms
+    // Handle editor/play camera transitions before play mode overwrites viewport 0.
     ERS_STRUCT_Scene* Scene = ProjectUtils_->SceneManager_->Scenes_[ProjectUtils_->SceneManager_->ActiveScene_].get();
-    if (!IsEditorMode_ && Scene->ActiveSceneCameraIndex != -1) {
+    if (LastEditorMode_ && !IsEditorMode_) {
+        StoreEditorViewportCameraState();
+    } else if (!LastEditorMode_ && IsEditorMode_) {
+        RestoreEditorViewportCameraState();
+    }
+    LastEditorMode_ = IsEditorMode_;
+
+    // Apply Scene Camera Transforms
+    if (!IsEditorMode_ && Scene->ActiveSceneCameraIndex != -1 && !Viewports_.empty()) {
         ERS_STRUCT_Camera* Camera = Viewports_[0]->Camera.get();
         ERS_STRUCT_SceneCamera* SceneCamera = Scene->SceneCameras[Scene->ActiveSceneCameraIndex].get();
         if (SceneCamera->EnforceAspectRatio_) {
@@ -450,11 +498,6 @@ void ERS_CLASS_VisualRenderer::SetScriptDebug(int Index, std::vector<std::string
 }
 
 void ERS_CLASS_VisualRenderer::UpdateViewport(int Index, ERS_CLASS_SceneManager* SceneManager, float DeltaTime, bool DrawCursor) {
-
-    //todo: check if is Viewport0. then check if the system is in running mode or editor mode. if it's both, then do the following:
-    // on transition, store the current editor position / rotation of the camera
-    // update the camera's position/rot to the scene's active scenecamera position/rot 
-    // disable user input directly through the editor system (the user will have to handle this via the scripting system)
 
     // Get Vars
     ERS_STRUCT_Viewport* Viewport = Viewports_[Index].get();

--- a/Source/Core/Renderer/ERS_CLASS_VisualRenderer/VisualRenderer.h
+++ b/Source/Core/Renderer/ERS_CLASS_VisualRenderer/VisualRenderer.h
@@ -77,6 +77,15 @@ private:
 
     long int FrameNumber_               = 0; /**<Frame counter, starts at 0*/
     int      ActiveViewportCursorIndex_ = 0; /**<The index of the viewport which the gizmo is being interacted with*/
+    bool     LastEditorMode_             = true;  /**<Editor/play mode state observed during the previous viewport update.*/
+    bool     HasStoredEditorCameraState_ = false; /**<True when viewport 0 editor camera state can be restored after play mode.*/
+
+    glm::vec3 StoredEditorCameraPosition_ = glm::vec3(0.0f); /**<Viewport 0 editor camera position before play mode.*/
+    glm::vec3 StoredEditorCameraRotation_ = glm::vec3(0.0f); /**<Viewport 0 editor camera rotation before play mode.*/
+    float     StoredEditorCameraFOV_      = 70.0f;           /**<Viewport 0 editor camera FOV before play mode.*/
+    float     StoredEditorCameraNearClip_ = 0.01f;           /**<Viewport 0 editor camera near clip before play mode.*/
+    float     StoredEditorCameraFarClip_  = 100.0f;          /**<Viewport 0 editor camera far clip before play mode.*/
+    int       StoredEditorCameraPriority_ = 1;               /**<Viewport 0 editor camera streaming priority before play mode.*/
 
 
 public:
@@ -100,7 +109,7 @@ private:
 
     /**
      * @brief Resize a viewport of specified index to the set width and height
-     * 
+     *
      * @param Index 
      * @param Width 
      * @param Height 
@@ -109,7 +118,7 @@ private:
 
     /**
      * @brief Update the shader used
-     * 
+     *
      * @param DeltaTime 
      * @param RenderWidth 
      * @param RenderHeight 
@@ -120,12 +129,24 @@ private:
 
     /**
      * @brief Updates a specific vieport of given index (should be used in update viepowrts function)
-     * 
+     *
      * @param Index 
      * @param SceneManager 
      * @param DeltaTime 
      */
     void UpdateViewport(int Index, ERS_CLASS_SceneManager* SceneManager, float DeltaTime, bool DrawCursor = true);
+
+    /**
+     * @brief Stores viewport 0's editor camera state before play mode applies a scene camera.
+     *
+     */
+    void StoreEditorViewportCameraState();
+
+    /**
+     * @brief Restores viewport 0's editor camera state after leaving play mode.
+     *
+     */
+    void RestoreEditorViewportCameraState();
 
 
 


### PR DESCRIPTION
I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Summary
- store viewport 0's editor camera state before play mode applies the active scene camera
- restore that editor camera state when returning from play mode
- sync the viewport input processor to the restored camera position, rotation, FOV, and clip bounds so editor navigation resumes from the restored view
- remove the completed viewport 0 play-mode transition TODO

## Verification
- `git diff --check`
- source search confirming the old viewport 0 transition TODO is removed and the store/restore transition hooks are wired
- focused C++17 transition probe covering editor -> play storage and play -> editor restore of camera and input processor state
- clean full-branch patch apply against a temporary `origin/master` worktree

Local full CMake configure still cannot start in this ERS checkout because `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` is missing and CMake cannot find a Unix Makefiles build program (`CMAKE_MAKE_PROGRAM` is unset).
