### PR TITLE
Read scene assets by byte length

### DIFF
--- a/Source/Core/Loader/ERS_SceneLoader/SceneLoader.cpp
+++ b/Source/Core/Loader/ERS_SceneLoader/SceneLoader.cpp
@@ -31,7 +31,10 @@ ERS_STRUCT_Scene ERS_CLASS_SceneLoader::ProcessScene(long AssetID) {
 
 
     // Load Then Process Scene
-    std::string SceneDataString = std::string((const char*)SceneData->Data.get());
+    std::string SceneDataString;
+    if (SceneData->Data != nullptr && SceneData->Size_B > 0) {
+        SceneDataString.assign(reinterpret_cast<const char*>(SceneData->Data.get()), SceneData->Size_B);
+    }
     YAML::Node SceneNode = YAML::Load(SceneDataString);
 
     return ProcessScene(SceneNode, AssetID);


### PR DESCRIPTION
Summary
- Read scene asset bytes using `IOData::Size_B` instead of treating the asset buffer as a null-terminated C string.
- Guard empty/null scene asset buffers before loading YAML.

Verification
- Source probe confirming `SceneLoader` uses `SceneData->Size_B` and no longer constructs a C string from the raw asset pointer.
- Standalone C++17 byte-length string probe preserving embedded null/trailing bytes.
- git diff --check
- Clean patch apply against origin/master with `git apply --check --whitespace=error-all`
- `cmake -S . -B /tmp/ers-scene-loader-sized-read-cmake` was attempted but local configure is blocked by the known missing `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` toolchain file and unset `CMAKE_MAKE_PROGRAM` for Unix Makefiles.

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.
