### PR TITLE
Read shader assets by byte length

### DIFF
--- a/Source/Core/Loader/ERS_ShaderLoader/ShaderLoader.cpp
+++ b/Source/Core/Loader/ERS_ShaderLoader/ShaderLoader.cpp
@@ -5,6 +5,21 @@
 #include <ShaderLoader.h>
 
 
+namespace {
+
+std::string ShaderTextFromAssetData(const BG::ERS::IOSubsystem::IOData& AssetData) {
+
+    if (AssetData.Data == nullptr || AssetData.Size_B == 0) {
+        return "";
+    }
+
+    return std::string(reinterpret_cast<const char*>(AssetData.Data.get()), AssetData.Size_B);
+
+}
+
+}
+
+
 ERS_CLASS_ShaderLoader::ERS_CLASS_ShaderLoader(ERS_STRUCT_SystemUtils* SystemUtils) {
 
     SystemUtils_ = SystemUtils;
@@ -90,27 +105,27 @@ void ERS_CLASS_ShaderLoader::LoadShaderFromAsset(ERS_STRUCT_Shader* ShaderStruct
 
     if (GeometryID != -1) {
         SystemUtils_->ERS_IOSubsystem_->ReadAsset(GeometryID, GeometryData.get());
-        GeometryText = std::string((const char*)GeometryData->Data.get());
+        GeometryText = ShaderTextFromAssetData(*GeometryData);
     }
 
     if (ComputeID != -1) {
         SystemUtils_->ERS_IOSubsystem_->ReadAsset(ComputeID, ComputeData.get());
-        ComputeText = std::string((const char*)ComputeData->Data.get());
+        ComputeText = ShaderTextFromAssetData(*ComputeData);
     }
 
     if (TCID != -1) {
         SystemUtils_->ERS_IOSubsystem_->ReadAsset(TCID, TCData.get());
-        TCText = std::string((const char*)TCData->Data.get());
+        TCText = ShaderTextFromAssetData(*TCData);
     }
 
     if (TEID != -1) {
         SystemUtils_->ERS_IOSubsystem_->ReadAsset(TEID, TEData.get());
-        TEText = std::string((const char*)TEData->Data.get());
+        TEText = ShaderTextFromAssetData(*TEData);
     }
 
 
-    std::string VertexText = std::string((const char*)VertexData->Data.get());
-    std::string FragmentText = std::string((const char*)FragmentData->Data.get());
+    std::string VertexText = ShaderTextFromAssetData(*VertexData);
+    std::string FragmentText = ShaderTextFromAssetData(*FragmentData);
 
 
     // Return Compiled Shader


### PR DESCRIPTION
## Summary
- convert shader-stage IOData buffers to source strings using `Size_B` instead of C-string termination
- return empty source text for missing or empty optional shader assets instead of dereferencing null data

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `rg -n "std::string\\(\\(const char\\*\\).*Data\\.get\\(\\)|ShaderTextFromAssetData|Size_B" Source/Core/Loader/ERS_ShaderLoader/ShaderLoader.cpp`
- `clang++ -std=c++17 -Wall -Wextra -pedantic -x c++ -o /tmp/ers-shader-asset-string-probe - <<'CPP' ... && /tmp/ers-shader-asset-string-probe`
- `git diff --check`
- clean patch apply against a fresh `origin/master` checkout with `git apply --check --whitespace=error-all`

Full local ERS build remains blocked before compilation: `cd Tools && bash Build.sh 4 Debug` reports `permission denied` and `CMake Error: Generator: build tool execution failed, command was:  -f Makefile -j4 ERS`, consistent with the missing configured Unix Makefiles build tool in this checkout.
