### PR TITLE
Preserve sparse model texture levels

### DIFF
--- a/Source/Core/Loader/ERS_ModelLoader/ModelMetadataDecoderManager.cpp
+++ b/Source/Core/Loader/ERS_ModelLoader/ModelMetadataDecoderManager.cpp
@@ -2,6 +2,9 @@
 // This file is part of the BrainGenix-ERS Environment Rendering System //
 //======================================================================//
 
+// cppcheck-suppress missingIncludeSystem
+#include <algorithm>
+
 #include <ModelMetadataDecoderManager.h>
 
 
@@ -37,17 +40,11 @@ bool ERS_FUNCTION_DecodeModelMetadata(YAML::Node Metadata, ERS_STRUCT_Model* Mod
     // Sort All Texture Levels
     for (unsigned int TextureIndex = 0; TextureIndex < Model->Textures_.size(); TextureIndex++) {
 
-        ERS_STRUCT_Texture* Texture = &Model->Textures_[TextureIndex];
-        std::vector<ERS_STRUCT_TextureLevel> InputTextureLevels = Texture->TextureLevels;
-        std::vector<ERS_STRUCT_TextureLevel> OutputTextureLevels;
-        for (unsigned int TextureLevelIndex = 0; TextureLevelIndex < Texture->TextureLevels.size(); TextureLevelIndex++) {
-            for (unsigned int i = 0; i < InputTextureLevels.size(); i++) {
-                if (InputTextureLevels[i].Level == (int)TextureLevelIndex) {
-                    OutputTextureLevels.push_back(InputTextureLevels[i]);
-                }
-            }
-        }
-        Texture->TextureLevels = OutputTextureLevels;
+        auto& TextureLevels = Model->Textures_[TextureIndex].TextureLevels;
+        std::stable_sort(TextureLevels.begin(), TextureLevels.end(),
+            [](const ERS_STRUCT_TextureLevel& A, const ERS_STRUCT_TextureLevel& B) {
+                return A.Level < B.Level;
+            });
     }
 
     return Status;


### PR DESCRIPTION
Summary:
- sort decoded model texture levels in place with stable_sort
- preserve sparse legacy texture level numbers instead of dropping levels above TextureLevels.size() - 1

Verification:
- git diff --check
- source probe confirming the old OutputTextureLevels reconstruction is gone and stable_sort is used
- standalone C++ sparse texture level probe preserving levels {2, 0, 2} as {0, 2, 2}
- clean patch apply against origin/master
- c++ -std=c++17 -ISource/Core/Loader/ERS_ModelLoader -ISource/Core -ISource/Renderer -fsyntax-only Source/Core/Loader/ERS_ModelLoader/ModelMetadataDecoderManager.cpp (blocked: missing yaml-cpp/yaml.h)
- cmake -S . -B /tmp/ers-model-metadata-sparse-levels-cmake (blocked: missing ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake and Unix Makefiles build program / CMAKE_MAKE_PROGRAM)

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.