### PR TITLE
Handle malformed local config files

### DIFF
--- a/Source/Internal/LocalConfigLoader/LocalConfigLoader.cpp
+++ b/Source/Internal/LocalConfigLoader/LocalConfigLoader.cpp
@@ -10,16 +10,16 @@ namespace ERS {
 namespace Module {
 
 
-bool TryWorkingPath(std::string Path) {
+bool TryWorkingPath(std::string Path, YAML::Node& Configuration) {
 
     // Enter Folder
     chdir(Path.c_str());
 
     // Check If Good
     try {
-        YAML::LoadFile("Config.yaml");
+        Configuration = YAML::LoadFile("Config.yaml");
         return true;
-    } catch (YAML::BadFile&) {
+    } catch (const YAML::Exception&) {
         return false;
     }
 
@@ -64,17 +64,13 @@ void ChuckErrorAndGiveUp() {
 bool LoadLocalConfiguration(std::string Path, YAML::Node& Configuration) {
 
     // Try a bunch of differet paths, chuck an error at the end and give up
-    if (TryWorkingPath(".")) {
-        Configuration = YAML::LoadFile("Config.yaml");
+    if (TryWorkingPath(".", Configuration)) {
         return true;
-    } else if (TryWorkingPath("../Resources")) {
-        Configuration = YAML::LoadFile("Config.yaml");
+    } else if (TryWorkingPath("../Resources", Configuration)) {
         return true;
-    } else if (TryWorkingPath(GetExecutableDirectory())) {
-        Configuration = YAML::LoadFile("Config.yaml");
+    } else if (TryWorkingPath(GetExecutableDirectory(), Configuration)) {
         return true;
-    } else if (TryWorkingPath("../Resources")) {
-        Configuration = YAML::LoadFile("Config.yaml");
+    } else if (TryWorkingPath("../Resources", Configuration)) {
         return true;
     } else {
         ChuckErrorAndGiveUp();


### PR DESCRIPTION
I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Summary
- Treat any yaml-cpp load exception as a failed local config candidate path
- Load the selected `Config.yaml` into the output node during the guarded probe instead of reloading it unguarded

## Verification
- git diff --check
- focused source probe confirming guarded `YAML::LoadFile`, `YAML::Exception` catch, and no unguarded reload in `LoadLocalConfiguration()`
- standalone C++17 exception probe covering success, missing-file, and parser-exception cases
- clean patch apply against fresh origin/master
- attempted LocalConfigLoader.cpp syntax check; blocked by missing `yaml-cpp/yaml.h`
- attempted CMake configure; blocked by missing `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` and unset `CMAKE_MAKE_PROGRAM`