### PR TITLE
Fix Lua light blue color globals

### DIFF
--- a/Source/Core/Script/ERS_CLASS_LuaJITInterpreterIntegration/ERS_CLASS_LuaJITInterpreterIntegration.cpp
+++ b/Source/Core/Script/ERS_CLASS_LuaJITInterpreterIntegration/ERS_CLASS_LuaJITInterpreterIntegration.cpp
@@ -184,7 +184,7 @@ lua_State* L = luaL_newstate();
     lua_pushnumber(L, PointLight->Color.g);
     lua_setglobal(L, "ColorG");
     lua_pushnumber(L, PointLight->Color.b);
-    lua_setglobal(L, "ColoarB");
+    lua_setglobal(L, "ColorB");
     lua_pushnumber(L, PointLight->Intensity);
     lua_setglobal(L, "Intensity");
     lua_pushnumber(L, PointLight->MaxDistance);
@@ -247,7 +247,7 @@ bool ERS_CLASS_LuaJITInterpreterIntegration::ExecuteDirectionalLightScript(std::
     lua_pushnumber(L, DirectionalLight->Color.g);
     lua_setglobal(L, "ColorG");
     lua_pushnumber(L, DirectionalLight->Color.b);
-    lua_setglobal(L, "ColoarB");
+    lua_setglobal(L, "ColorB");
     lua_pushnumber(L, DirectionalLight->Intensity);
     lua_setglobal(L, "Intensity");
     lua_pushnumber(L, DirectionalLight->MaxDistance);
@@ -316,7 +316,7 @@ bool ERS_CLASS_LuaJITInterpreterIntegration::ExecuteSpotLightScript(std::string 
     lua_pushnumber(L, SpotLight->Color.g);
     lua_setglobal(L, "ColorG");
     lua_pushnumber(L, SpotLight->Color.b);
-    lua_setglobal(L, "ColoarB");
+    lua_setglobal(L, "ColorB");
     lua_pushnumber(L, SpotLight->Intensity);
     lua_setglobal(L, "Intensity");
     lua_pushnumber(L, SpotLight->MaxDistance);


### PR DESCRIPTION
## Summary
- publish point, directional, and spot light blue color values as ColorB in Lua scripts
- keep the Lua writeback key aligned with the setup key so scripts that do not override blue preserve the existing color

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Testing
- rg -n "ColoarB" Source/Core/Script/ERS_CLASS_LuaJITInterpreterIntegration Source
- rg -n "ColoarB|ColorB" Source/Core/Script/ERS_CLASS_LuaJITInterpreterIntegration/ERS_CLASS_LuaJITInterpreterIntegration.cpp
- git diff --check origin/master
- clean origin/master worktree patch apply with git apply --check --whitespace=error-all
- standalone C++17 string probe for ColorB key consistency
- c++ -std=c++17 -fsyntax-only Source/Core/Script/ERS_CLASS_LuaJITInterpreterIntegration/ERS_CLASS_LuaJITInterpreterIntegration.cpp (blocked locally: missing lua.hpp)
- bash Build.sh 4 Debug from Tools (blocked locally: CMake build tool command is empty / permission denied)