### PR TITLE
Fix non-Apple executable path lookup

### DIFF
--- a/Source/Internal/GetExecutablePath/GetExecutablePath.cpp
+++ b/Source/Internal/GetExecutablePath/GetExecutablePath.cpp
@@ -11,6 +11,32 @@ namespace Module {
 
 
 
+#ifndef __APPLE__
+static std::string GetWhereAmIPath(int (*PathGetter)(char*, int, int*), bool ReturnDirectory) {
+    int DirectoryNameLength = 0;
+    int Length = PathGetter(nullptr, 0, &DirectoryNameLength);
+    if (Length <= 0) {
+        return "Unable To Get Binary Path";
+    }
+
+    std::string Path(static_cast<size_t>(Length), '\0');
+    Length = PathGetter(&Path[0], Length, &DirectoryNameLength);
+    if (Length <= 0) {
+        return "Unable To Get Binary Path";
+    }
+
+    Path.resize(static_cast<size_t>(Length));
+    if (ReturnDirectory) {
+        if (DirectoryNameLength <= 0) {
+            return "";
+        }
+        Path.resize(static_cast<size_t>(DirectoryNameLength));
+    }
+
+    return Path;
+}
+#endif
+
 
 
 std::string GetExecutablePath() {
@@ -23,15 +49,7 @@ std::string GetExecutablePath() {
         return std::string(buf);
     #else
 
-        char* Path = NULL;
-        int Length, DirectoryNameLength;
-        Length = wai_getExecutablePath(Path, 0, &DirectoryNameLength);
-        
-        if (Path == NULL) {
-            return "Unable To Get Binary Path";
-        }
-
-        return std::string(Path);
+        return GetWhereAmIPath(wai_getExecutablePath, false);
     #endif
 }
 
@@ -45,16 +63,7 @@ std::string GetExecutableDirectory() {
         return std::string(buf).substr(0, std::string(buf).find_last_of("/"));
     #else
 
-        char* Path = NULL;
-        int Length, DirectoryNameLength;
-        Length = wai_getModulePath(Path, 0, &DirectoryNameLength);
-        
-
-        if (Path == NULL) {
-            return "Unable To Get Binary Path";
-        }
-
-        return std::string(Path);
+        return GetWhereAmIPath(wai_getExecutablePath, true);
     #endif
 }
 


### PR DESCRIPTION
Summary
- Use whereami's two-call pattern on non-Apple platforms so executable path lookup allocates a real buffer before reading.
- Return the executable directory from the executable path dirname instead of returning an unread module path.
- Preserve the existing fallback string when whereami cannot report a path.

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.\n\nVerification\n- git diff --check\n- clang++ -std=c++17 -fsyntax-only Source/Internal/GetExecutablePath/GetExecutablePath.cpp -ISource/Internal/GetExecutablePath -IThirdParty/NonSuperBuild/whereami/src\n- Focused source probe confirming two-call whereami allocation and no null-buffer path remains.\n- Standalone C++17 allocation probe covering full-path, dirname, first-call failure, and second-call failure cases.\n- Clean patch apply against fresh origin/master.\n\nBuild note\n- cd Tools && bash Build.sh 4 Debug is still blocked locally by the known generator state: permission denied, then CMake reports an empty build-tool command (` -f Makefile -j4 ERS`).